### PR TITLE
systemd unit files

### DIFF
--- a/contrib/rorserver.conf.in
+++ b/contrib/rorserver.conf.in
@@ -1,0 +1,14 @@
+# /etc/xdg/rorserver/rorserver.conf
+#
+# Environment configuration file for Rigs of Rods server. Not used by the client.
+
+# Resources
+RESDIR=@CMAKE_INSTALL_PREFIX@/share/rorserver
+
+# Configuration
+CFGDIR=/etc/xdg/rorserver
+CONFIG=/etc/xdg/rorserver/server.cfg
+
+# Logging
+LOGDIR=/var/log/rorserver
+LOGFILE=/var/log/rorserver/server.log

--- a/contrib/rorserver.service.in
+++ b/contrib/rorserver.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=Rigs of Rods dedicated server
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/xdg/rorserver/rorserver.conf
+User=rorserver
+Group=rorserver
+ExecStart=@CMAKE_INSTALL_PREFIX@/bin/rorserver -c $CONFIG -resdir $RESDIR -logfilename $LOGFILE -inet
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This pull request contains the files necessary for launching and controlling server via systemd on Linux. 

This way is more convenient yet has limited debugging and allows for only one running instance per host. Also note different directory layout, consistent with systemd/journald based systems (e.g. Arch Linux).