### PR TITLE
Travis: Integrate static code analysis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,13 @@ env:
   - ANALYZE=false
   - ANALYZE=true
 
-before_script:
+before_install:
   - chmod +x ./tools/travis/linux/travis.sh
   - chmod +x ./tools/travis/linux/build.sh
 
-  - sudo apt-get install cppcheck
+  - sudo add-apt-repository -qq ppa:ubuntu-toolchain-r/test
+  - sudo apt-get -qq update
+  - sudo apt-get install cppcheck clang
 
 script:
   - ./tools/travis/linux/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ before_install:
   - chmod +x ./tools/travis/linux/travis.sh
   - chmod +x ./tools/travis/linux/build.sh
 
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get -qq update
-  - sudo apt-get install cppcheck clang
+install:
+  # only install clang/cppcheck if necessary
+  - if [ "$CXX" = "clang" ]; then sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y; sudo apt-get -qq update; sudo apt-get install clang; fi
+  - if [ $ANALYZE = "true" ] && [ "$CXX" = "g++" ]; then sudo apt-get install -qq cppcheck; fi
 
 script:
   - ./tools/travis/linux/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,18 @@ compiler:
   - gcc
   - clang
 
+env:
+  - ANALYZE=false
+  - ANALYZE=true
+
 before_script:
+  - chmod +x ./tools/travis/linux/travis.sh
   - chmod +x ./tools/travis/linux/build.sh
 
+  - sudo apt-get install cppcheck
+
 script:
-  - ./tools/travis/linux/build.sh
+  - ./tools/travis/linux/travis.sh
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - chmod +x ./tools/travis/linux/travis.sh
   - chmod +x ./tools/travis/linux/build.sh
 
-  - sudo add-apt-repository -qq ppa:ubuntu-toolchain-r/test
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get -qq update
   - sudo apt-get install cppcheck clang
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 
 install:
   # only install clang/cppcheck if necessary
-  - if [ "$CXX" = "clang" ]; then sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y; sudo apt-get -qq update; sudo apt-get install clang; fi
+  - if [ "$CXX" = "clang++" ]; then sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y; sudo apt-get -qq update; sudo apt-get install clang; fi
   - if [ $ANALYZE = "true" ] && [ "$CXX" = "g++" ]; then sudo apt-get install -qq cppcheck; fi
 
 script:

--- a/tools/travis/linux/travis.sh
+++ b/tools/travis/linux/travis.sh
@@ -22,7 +22,7 @@ if [ $ANALYZE = "true" ]; then
         cppcheck --version
         cppcheck \
           --template "{file}({line}): {severity} ({id}): {message}" \
-          --enable=information --enable=warning --enable=performance \
+          --enable=information --enable=performance \
           --force --std=c++11 -j2 . 2> cppcheck.txt
         if [ -s cppcheck.txt ]; then
             cat cppcheck.txt

--- a/tools/travis/linux/travis.sh
+++ b/tools/travis/linux/travis.sh
@@ -23,7 +23,7 @@ if [ $ANALYZE = "true" ]; then
         cppcheck \
           --template "{file}({line}): {severity} ({id}): {message}" \
           --enable=information --enable=performance \
-          --force --std=c++11 -j2 . 2> cppcheck.txt
+          --force --std=c++11 -j2 ./source 2> cppcheck.txt
         if [ -s cppcheck.txt ]; then
             cat cppcheck.txt
             exit 1

--- a/tools/travis/linux/travis.sh
+++ b/tools/travis/linux/travis.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+#
+# Build script for travis-ci.org builds to handle compiles 
+# and static analysis when ANALYZE=true.
+#
+if [ $ANALYZE = "true" ]; then
+    if [ "$CC" = "clang" ]; then
+        scan-build cmake -G "Unix Makefiles" \
+          -DCMAKE_INSTALL_PREFIX:STRING=/usr \
+          -DRORSERVER_NO_STACKLOG:BOOL=ON \
+          -DRORSERVER_CRASHHANDLER:BOOL=ON \
+          -DRORSERVER_GUI:BOOL=ON \
+          -DRORSERVER_WITH_ANGELSCRIPT:BOOL=ON \
+          -DRORSERVER_WITH_WEBSERVER:BOOL=OFF \
+          .
+        scan-build \
+          -enable-checker security.FloatLoopCounter \
+          -enable-checker security.insecureAPI.UncheckedReturn \
+          --status-bugs -v \
+          make -j2
+    else
+        cppcheck --version
+        cppcheck \
+          --template "{file}({line}): {severity} ({id}): {message}" \
+          --enable=information --enable=warning --enable=performance \
+          --force --std=c++11 -j2 . 2> cppcheck.txt
+        if [ -s cppcheck.txt ]; then
+            cat cppcheck.txt
+            exit 1
+        fi
+    fi
+else # no static analysis, do regular build
+    ./tools/travis/linux/build.sh
+fi


### PR DESCRIPTION
This PR adds static code analysis to Travis CI.
In addition to just build the code both clang's scan-build and cppcheck will check the code for defects.

You will be able to see the output of clang and cppcheck on the Travis page for ror-server: https://travis-ci.org/RigsOfRods/ror-server
* gcc with ANALYZE=true will run cppcheck
* clang with ANALYZE=true will run scan-build
* if ANALYZE=false then a regular build will be performed

"Analyze builds" fail on Travis if scan-build or cppcheck detect defects.

Always remember: static code analyzers may show false positives so double-check what you are fixing.

Example: https://travis-ci.org/Hiradur/ror-server