### PR TITLE
[Fix] User authorizations in LAN Mode

### DIFF
--- a/source/server/sequencer.cpp
+++ b/source/server/sequencer.cpp
@@ -110,13 +110,9 @@ void Sequencer::initilize()
 
 	instance->authresolver = 0;
 	instance->notifier = 0;
-	if( Config::getServerMode() != SERVER_LAN )
-	{
-		instance->notifier = new Notifier(instance->authresolver);
-
-		// start userauth
-		instance->authresolver = new UserAuth(instance->notifier->getChallenge(), instance->notifier->getTrustLevel(), Config::getAuthFile());
-	}
+	instance->notifier = new Notifier(instance->authresolver);
+	// start userauth
+	instance->authresolver = new UserAuth(instance->notifier->getChallenge(), instance->notifier->getTrustLevel(), Config::getAuthFile());
 }
 
 /**


### PR DESCRIPTION
Servers started in LAN mode did not read the authorization file, thus
disabling them. The code was under a if statement for some reason.
I don't know much about C++, I just fixed this till the new master
server is finished. Only tested on Debian 7.9.