### PR TITLE
[Fix] Building with Visual Studio 2015

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything under /bin except where specified
+bin/*
+!bin/resources/*
+!bin/pthreadVC2.dll

--- a/dependencies/socketw/sw_base.h
+++ b/dependencies/socketw/sw_base.h
@@ -18,7 +18,9 @@
 
 #include "sw_internal.h"
 
-#include <unistd.h>
+#ifndef _WIN32 // Microsoft Visual Studio has no <unistd.h>
+#   include <unistd.h>
+#endif
 #include <string>
 
 // Set error handling mode

--- a/dependencies/win32_pthread/pthread.h
+++ b/dependencies/win32_pthread/pthread.h
@@ -116,6 +116,10 @@
 #   pragma comment(lib, "pthread")
 #endif
 
+#if _MSC_VER == 1900 // Visual Studio 2015
+#   define HAVE_STRUCT_TIMESPEC // Defined in <time.h> from Windows 10 SDK
+#endif
+
 /*
  * -------------------------------------------------------------
  *


### PR DESCRIPTION
Hi.

I'm about to update the server to talk to our new serverlist: https://github.com/only-a-ptr/multiplayer.rigsofrods.org

I started by building the server under Visual Studio 2015. It didn't go smoothly. A few hacks were needed.

Even this way, the build is still not clean:
```

2>d:\projects\git\ror-server\ror-server\dependencies\socketw\sw_base.h(82): warning C4251: 'SWBaseSocket::SWBaseError::error_string': class 'std::basic_string<char,std::char_traits<char>,std::allocator<char>>' needs to have dll-interface to be used by clients of class 'SWBaseSocket::SWBaseError' (compiling source file D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_inet.cxx)
2>d:\projects\git\ror-server\ror-server\dependencies\socketw\sw_base.h(183): warning C4251: 'SWBaseSocket::error_string': class 'std::basic_string<char,std::char_traits<char>,std::allocator<char>>' needs to have dll-interface to be used by clients of class 'SWBaseSocket' (compiling source file D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_inet.cxx)
2>D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_inet.cxx(87): warning C4996: 'gethostbyname': Use getaddrinfo() or GetAddrInfoW() instead or define _WINSOCK_DEPRECATED_NO_WARNINGS to disable deprecated API warnings
2>  C:\Program Files (x86)\Windows Kits\8.1\Include\um\winsock2.h(2238): note: see declaration of 'gethostbyname'
2>D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_inet.cxx(123): warning C4996: 'gethostbyname': Use getaddrinfo() or GetAddrInfoW() instead or define _WINSOCK_DEPRECATED_NO_WARNINGS to disable deprecated API warnings
2>  C:\Program Files (x86)\Windows Kits\8.1\Include\um\winsock2.h(2238): note: see declaration of 'gethostbyname'
2>D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_inet.cxx(154): warning C4996: 'inet_ntoa': Use inet_ntop() or InetNtop() instead or define _WINSOCK_DEPRECATED_NO_WARNINGS to disable deprecated API warnings
2>  C:\Program Files (x86)\Windows Kits\8.1\Include\um\winsock2.h(1868): note: see declaration of 'inet_ntoa'
2>D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_inet.cxx(185): warning C4996: 'gethostbyname': Use getaddrinfo() or GetAddrInfoW() instead or define _WINSOCK_DEPRECATED_NO_WARNINGS to disable deprecated API warnings
2>  C:\Program Files (x86)\Windows Kits\8.1\Include\um\winsock2.h(2238): note: see declaration of 'gethostbyname'
2>D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_inet.cxx(207): warning C4996: 'gethostbyname': Use getaddrinfo() or GetAddrInfoW() instead or define _WINSOCK_DEPRECATED_NO_WARNINGS to disable deprecated API warnings
2>  C:\Program Files (x86)\Windows Kits\8.1\Include\um\winsock2.h(2238): note: see declaration of 'gethostbyname'
2>D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_inet.cxx(214): warning C4996: 'inet_ntoa': Use inet_ntop() or InetNtop() instead or define _WINSOCK_DEPRECATED_NO_WARNINGS to disable deprecated API warnings
2>  C:\Program Files (x86)\Windows Kits\8.1\Include\um\winsock2.h(1868): note: see declaration of 'inet_ntoa'
2>d:\projects\git\ror-server\ror-server\dependencies\socketw\sw_base.h(82): warning C4251: 'SWBaseSocket::SWBaseError::error_string': class 'std::basic_string<char,std::char_traits<char>,std::allocator<char>>' needs to have dll-interface to be used by clients of class 'SWBaseSocket::SWBaseError' (compiling source file D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx)
2>d:\projects\git\ror-server\ror-server\dependencies\socketw\sw_base.h(183): warning C4251: 'SWBaseSocket::error_string': class 'std::basic_string<char,std::char_traits<char>,std::allocator<char>>' needs to have dll-interface to be used by clients of class 'SWBaseSocket' (compiling source file D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx)
2>D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx(41): warning C4005: 'ENOTSOCK': macro redefinition
2>  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\errno.h(112): note: see previous definition of 'ENOTSOCK' (compiling source file D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx)
2>D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx(42): warning C4005: 'EOPNOTSUPP': macro redefinition
2>  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\errno.h(114): note: see previous definition of 'EOPNOTSUPP' (compiling source file D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx)
2>D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx(43): warning C4005: 'EADDRINUSE': macro redefinition
2>  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\errno.h(84): note: see previous definition of 'EADDRINUSE' (compiling source file D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx)
2>D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx(44): warning C4005: 'EWOULDBLOCK': macro redefinition
2>  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\errno.h(124): note: see previous definition of 'EWOULDBLOCK' (compiling source file D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx)
2>D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx(45): warning C4005: 'EMSGSIZE': macro redefinition
2>  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\errno.h(99): note: see previous definition of 'EMSGSIZE' (compiling source file D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx)
2>D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx(46): warning C4005: 'EINPROGRESS': macro redefinition
2>  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\errno.h(96): note: see previous definition of 'EINPROGRESS' (compiling source file D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx)
2>D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx(47): warning C4005: 'EALREADY': macro redefinition
2>  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\errno.h(87): note: see previous definition of 'EALREADY' (compiling source file D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx)
2>D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx(48): warning C4005: 'ECONNREFUSED': macro redefinition
2>  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\errno.h(91): note: see previous definition of 'ECONNREFUSED' (compiling source file D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx)
2>D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx(49): warning C4005: 'ETIMEDOUT': macro redefinition
2>  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\errno.h(122): note: see previous definition of 'ETIMEDOUT' (compiling source file D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx)
2>D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx(50): warning C4005: 'ENOTCONN': macro redefinition
2>  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10240.0\ucrt\errno.h(110): note: see previous definition of 'ENOTCONN' (compiling source file D:\Projects\Git\ror-server\ror-server\dependencies\socketw\sw_base.cxx)

```