### PR TITLE
[Codechange] Ignore jsoncpp warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,9 @@ endif()
 
 add_subdirectory("dependencies/socketw")
 add_subdirectory("dependencies/rudeconfig")
-add_subdirectory("dependencies/jsoncpp")
+
+#add_subdirectory("dependencies/jsoncpp")
+include_directories(SYSTEM dependencies/jsoncpp)
 
 add_subdirectory("source/server")
 


### PR DESCRIPTION
It works locally, but Travis doesn't seem to like it.