### PR TITLE
🔧 Minor config fixes

### DIFF
--- a/source/server/config.cpp
+++ b/source/server/config.cpp
@@ -50,9 +50,9 @@ static std::string s_terrain_name("any");
 static std::string s_public_password;
 static std::string s_ip_addr("0.0.0.0");
 static std::string s_scriptname;
-static std::string s_authfile("admins.txt");
-static std::string s_motdfile("motd.txt");
-static std::string s_rulesfile("rules.txt");
+static std::string s_authfile("server.auth");
+static std::string s_motdfile("server.motd");
+static std::string s_rulesfile("server.rules");
 static std::string s_owner;
 static std::string s_website;
 static std::string s_irc;
@@ -86,18 +86,18 @@ namespace Config {
                 "Usage: rorserver [OPTIONS]\n"
                         "[OPTIONS] can be in Un*x `--help` or windows `/help` notation\n"
                         "\n"
-                        " ~config-file (-c) <INI file> Loads the configuration from a file\n"
-                        " ~name <name>                 Name of the server, no spaces, only\n"
-                        "                              [a-z,0-9,A-Z]\n"
-                        " ~terrain <mapname>           Map name (defaults to 'any')\n"
-                        " ~max-clients|speed <clients> Maximum clients allowed\n"
-                        " ~lan|inet                    Private or public server (defaults to inet)\n"
+                        " -config-file (-c) <INI file> Loads the configuration from a file\n"
+                        " -name <name>                 Name of the server, no spaces, only\n"
+                        " -                            [a-z,0-9,A-Z]\n"
+                        " -terrain <mapname>           Map name (defaults to 'any')\n"
+                        " -max-clients|speed <clients> Maximum clients allowed\n"
+                        " -lan|inet                    Private or public server (defaults to inet)\n"
                         "\n"
-                        " ~password <password>         Private server password\n"
-                        " ~ip <ip>                     Public IP address to register with.\n"
-                        " ~port <port>                 Port to use (defaults to random 12000-12500)\n"
-                        " ~verbosity {0-5}             Sets displayed log verbosity\n"
-                        " ~log-verbosity {0-5}         Sets file log verbositylog verbosity\n"
+                        " -password <password>         Private server password\n"
+                        " -ip <ip>                     Public IP address to register with.\n"
+                        " -port <port>                 Port to use (defaults to random 12000-12500)\n"
+                        " -verbosity {0-5}             Sets displayed log verbosity\n"
+                        " -log-verbosity {0-5}         Sets file log verbositylog verbosity\n"
                         "                              levels available to verbosity and logverbosity:\n"
                         "                                  0 = stack\n"
                         "                                  1 = debug\n"
@@ -105,22 +105,22 @@ namespace Config {
                         "                                  3 = info\n"
                         "                                  4 = warn\n"
                         "                                  5 = error\n"
-                        " ~log-file <server.log>       Sets the filename of the log\n"
-                        " ~script-file <script.as>     server script to execute\n"
-                        " ~use-webserver               enables the built-in webserver\n"
-                        " ~webserver-port <number>     sets up the port for the webserver, default is game port + 100\n"
-                        " ~version                     prints the server version numbers\n"
-                        " ~fg                          starts the server in the foreground (background by default)\n"
-                        " ~resource-dir <path>         sets the path to the resource directory\n"
-                        " ~auth-file <server.auth>     Sets the filename of the file that contains authorization info\n"
-                        " ~motdf-ile <server.motd>     Sets the filename of the file that contains the message of the day\n"
-                        " ~rules-file <server.rules>   Sets the filename of the file that contains rules for this server\n"
-                        " ~vehicle-limit {0-...}       Sets the maximum number of vehicles that a user is allowed to have\n"
-                        " ~owner <name|organisation>   Sets the owner of this server (for the !owner command) (optional)\n"
-                        " ~website <URL>               Sets the website of this server (for the !website command) (optional)\n"
-                        " ~irc <URL>                   Sets the IRC url for this server (for the !irc command) (optional)\n"
-                        " ~voip <URL>                  Sets the voip url for this server (for the !voip command) (optional)\n"
-                        " ~help                        Show this list\n");
+                        " -log-file <server.log>       Sets the filename of the log\n"
+                        " -script-file <script.as>     Server script to execute\n"
+                        " -use-webserver               Enables the built-in webserver\n"
+                        " -webserver-port <number>     Sets up the port for the webserver, default is game port + 100\n"
+                        " -version                     Prints the server version numbers\n"
+                        " -fg                          Starts the server in the foreground (background by default)\n"
+                        " -resource-dir <path>         Sets the path to the resource directory\n"
+                        " -auth-file <server.auth>     Sets the filename of the file that contains authorization info\n"
+                        " -motd-file <server.motd>     Sets the filename of the file that contains the message of the day\n"
+                        " -rules-file <server.rules>   Sets the filename of the file that contains rules for this server\n"
+                        " -vehicle-limit {0-...}       Sets the maximum number of vehicles that a user is allowed to have\n"
+                        " -owner <name|organisation>   Sets the owner of this server (for the !owner command) (optional)\n"
+                        " -website <URL>               Sets the website of this server (for the !website command) (optional)\n"
+                        " -irc <URL>                   Sets the IRC url for this server (for the !irc command) (optional)\n"
+                        " -voip <URL>                  Sets the voip url for this server (for the !voip command) (optional)\n"
+                        " -help                        Show this list\n");
     }
 
     void ShowVersion() {
@@ -172,12 +172,12 @@ namespace Config {
 
         if (getAuthFile().empty()) {
             Logger::Log(LOG_ERROR, "Authorizations file not specified. Using default (admins.txt)");
-            setAuthFile("admins.txt");
+            setAuthFile("server.auth");
         }
 
         if (getMOTDFile().empty()) {
             Logger::Log(LOG_ERROR, "MOTD file not specified. Using default (motd.txt).");
-            setMOTDFile("motd.txt");
+            setMOTDFile("server.motd");
         }
 
         if (getMaxVehicles() < 1) {


### PR DESCRIPTION
- Fixes some typos in the help output
- Restores the default names of the `auth`, `motd` and `rules` config files to match the documented values: https://docs.rigsofrods.org/gameplay/multiplayer-server-setup/#running-the-server-using-cli-arguments