### PR TITLE
🔧 Fixed the packet queue handling

### DIFF
--- a/source/protocol/rornet.h
+++ b/source/protocol/rornet.h
@@ -23,13 +23,6 @@
 
 #define BITMASK(x) (1 << (x-1))
 
-#ifdef _MSC_VER          // MSVC: set global packing and make PACKED an empty macro
-#   pragma pack(push, 1)
-#   define PACKED
-#else                    // GCC/Clang: use standard attribute
-#   define PACKED __attribute__((packed))
-#endif
-
 namespace RoRnet {
 
 #define RORNET_MAX_PEERS            64     //!< maximum clients connected at the same time
@@ -37,154 +30,168 @@ namespace RoRnet {
 #define RORNET_LAN_BROADCAST_PORT   13000  //!< port used to send the broadcast announcement in LAN mode
 #define RORNET_MAX_USERNAME_LEN     40     //!< port used to send the broadcast announcement in LAN mode
 
-#define RORNET_VERSION              "RoRnet_2.40"
+#define RORNET_VERSION              "RoRnet_2.41"
 
-    enum MessageType {
-        MSG2_HELLO = 1025,                //!< client sends its version as first message
+enum MessageType
+{
+    MSG2_HELLO  = 1025,                //!< client sends its version as first message
+    
+    // Hello responses
+    MSG2_FULL,                         //!< no more slots for us
+    MSG2_WRONG_PW,                     //!< server send that on wrong pw
+    MSG2_WRONG_VER,                    //!< wrong version
+    MSG2_BANNED,                       //!< client not allowed to join
+    MSG2_WELCOME,                      //!< we can proceed
 
-        // Hello responses
-                MSG2_FULL,                         //!< no more slots for us
-        MSG2_WRONG_PW,                     //!< server send that on wrong pw
-        MSG2_WRONG_VER,                    //!< wrong version
-        MSG2_BANNED,                       //!< client not allowed to join
-        MSG2_WELCOME,                      //!< we can proceed
+    // Technical
+    MSG2_VERSION,                      //!< server responds with its version
+    MSG2_SERVER_SETTINGS,              //!< server send client the terrain name: server_info_t
+    MSG2_USER_INFO,                    //!< user data that is sent from the server to the clients
+    MSG2_MASTERINFO,                   //!< master information response
+    MSG2_NETQUALITY,                   //!< network quality information
 
-        // Technical
-                MSG2_VERSION,                      //!< server responds with its version
-        MSG2_SERVER_SETTINGS,              //!< server send client the terrain name: server_info_t
-        MSG2_USER_INFO,                    //!< user data that is sent from the server to the clients
-        MSG2_MASTERINFO,                   //!< master information response
-        MSG2_NETQUALITY,                   //!< network quality information
+    // Gameplay
+    MSG2_GAME_CMD,                     //!< Script message. Can be sent in both directions.
+    MSG2_USER_JOIN,                    //!< new user joined
+    MSG2_USER_LEAVE,                   //!< user leaves
+    MSG2_UTF8_CHAT,                    //!< chat line in UTF8 encoding
+    MSG2_UTF8_PRIVCHAT,                //!< private chat line in UTF8 encoding
 
-        // Gameplay
-                MSG2_GAME_CMD,                     //!< Script message. Can be sent in both directions.
-        MSG2_USER_JOIN,                    //!< new user joined
-        MSG2_USER_LEAVE,                   //!< user leaves
-        MSG2_UTF8_CHAT,                    //!< chat line in UTF8 encoding
-        MSG2_UTF8_PRIVCHAT,                //!< private chat line in UTF8 encoding
+    // Stream functions
+    MSG2_STREAM_REGISTER,              //!< create new stream
+    MSG2_STREAM_REGISTER_RESULT,       //!< result of a stream creation
+    MSG2_STREAM_UNREGISTER,            //!< remove stream
+    MSG2_STREAM_DATA,                  //!< stream data
 
-        // Stream functions
-                MSG2_STREAM_REGISTER,              //!< create new stream
-        MSG2_STREAM_REGISTER_RESULT,       //!< result of a stream creation
-        MSG2_STREAM_UNREGISTER,            //!< remove stream
-        MSG2_STREAM_DATA,                  //!< stream data
-    };
+    // Legacy values (RoRnet_2.38 and earlier)
+    MSG2_WRONG_VER_LEGACY = 1003       //!< Wrong version
+};
 
-    enum UserAuth {
-        AUTH_NONE = 0,                   //!< no authentication
-        AUTH_ADMIN = BITMASK(1),          //!< admin on the server
-        AUTH_RANKED = BITMASK(2),          //!< ranked status
-        AUTH_MOD = BITMASK(3),          //!< moderator status
-        AUTH_BOT = BITMASK(4),          //!< bot status
-        AUTH_BANNED = BITMASK(5)           //!< banned
-    };
+enum UserAuth
+{
+    AUTH_NONE   = 0,                   //!< no authentication
+    AUTH_ADMIN  = BITMASK(1),          //!< admin on the server
+    AUTH_RANKED = BITMASK(2),          //!< ranked status
+    AUTH_MOD    = BITMASK(3),          //!< moderator status
+    AUTH_BOT    = BITMASK(4),          //!< bot status
+    AUTH_BANNED = BITMASK(5)           //!< banned
+};
 
-    enum Netmask {
-        NETMASK_HORN = BITMASK(1),  //!< horn is in use
-        NETMASK_LIGHTS = BITMASK(2),  //!< lights on
-        NETMASK_BRAKES = BITMASK(3),  //!< brake lights on
-        NETMASK_REVERSE = BITMASK(4),  //!< reverse light on
-        NETMASK_BEACONS = BITMASK(5),  //!< beacons on
-        NETMASK_BLINK_LEFT = BITMASK(6),  //!< left blinker on
-        NETMASK_BLINK_RIGHT = BITMASK(7),  //!< right blinker on
-        NETMASK_BLINK_WARN = BITMASK(8),  //!< warn blinker on
-        NETMASK_CLIGHT1 = BITMASK(9),  //!< custom light 1 on
-        NETMASK_CLIGHT2 = BITMASK(10), //!< custom light 2 on
-        NETMASK_CLIGHT3 = BITMASK(11), //!< custom light 3 on
-        NETMASK_CLIGHT4 = BITMASK(12), //!< custom light 4 on
-        NETMASK_POLICEAUDIO = BITMASK(13), //!< police siren on
-        NETMASK_PARTICLE = BITMASK(14), //!< custom particles on
-        NETMASK_PBRAKE = BITMASK(15), //!< custom particles on
-        NETMASK_TC_ACTIVE = BITMASK(16), //!< traction control light on?
-        NETMASK_ALB_ACTIVE = BITMASK(17), //!< anti lock brake light on?
-        NETMASK_ENGINE_CONT = BITMASK(18), //!< ignition on?
-        NETMASK_ENGINE_RUN = BITMASK(19), //!< engine running?
+enum Netmask
+{
+    NETMASK_HORN        = BITMASK(1),  //!< horn is in use
+    NETMASK_LIGHTS      = BITMASK(2),  //!< lights on
+    NETMASK_BRAKES      = BITMASK(3),  //!< brake lights on
+    NETMASK_REVERSE     = BITMASK(4),  //!< reverse light on
+    NETMASK_BEACONS     = BITMASK(5),  //!< beacons on
+    NETMASK_BLINK_LEFT  = BITMASK(6),  //!< left blinker on
+    NETMASK_BLINK_RIGHT = BITMASK(7),  //!< right blinker on
+    NETMASK_BLINK_WARN  = BITMASK(8),  //!< warn blinker on
+    NETMASK_CLIGHT1     = BITMASK(9),  //!< custom light 1 on
+    NETMASK_CLIGHT2     = BITMASK(10), //!< custom light 2 on
+    NETMASK_CLIGHT3     = BITMASK(11), //!< custom light 3 on
+    NETMASK_CLIGHT4     = BITMASK(12), //!< custom light 4 on
+    NETMASK_POLICEAUDIO = BITMASK(13), //!< police siren on
+    NETMASK_PARTICLE    = BITMASK(14), //!< custom particles on
+    NETMASK_PBRAKE      = BITMASK(15), //!< custom particles on
+    NETMASK_TC_ACTIVE   = BITMASK(16), //!< traction control light on?
+    NETMASK_ALB_ACTIVE  = BITMASK(17), //!< anti lock brake light on?
+    NETMASK_ENGINE_CONT = BITMASK(18), //!< ignition on?
+    NETMASK_ENGINE_RUN  = BITMASK(19), //!< engine running?
 
-        NETMASK_ENGINE_MODE_AUTOMATIC = BITMASK(20), //!< engine mode
-        NETMASK_ENGINE_MODE_SEMIAUTO = BITMASK(21), //!< engine mode
-        NETMASK_ENGINE_MODE_MANUAL = BITMASK(22), //!< engine mode
-        NETMASK_ENGINE_MODE_MANUAL_STICK = BITMASK(23), //!< engine mode
-        NETMASK_ENGINE_MODE_MANUAL_RANGES = BITMASK(24)  //!< engine mode
-    };
+    NETMASK_ENGINE_MODE_AUTOMATIC     = BITMASK(20), //!< engine mode
+    NETMASK_ENGINE_MODE_SEMIAUTO      = BITMASK(21), //!< engine mode
+    NETMASK_ENGINE_MODE_MANUAL        = BITMASK(22), //!< engine mode
+    NETMASK_ENGINE_MODE_MANUAL_STICK  = BITMASK(23), //!< engine mode
+    NETMASK_ENGINE_MODE_MANUAL_RANGES = BITMASK(24)  //!< engine mode
+};
 
 // -------------------------------- structs -----------------------------------
 // Only use datatypes with defined binary sizes (avoid bool, int, wchar_t...)
 // Prefer alignment to 4 or 2 bytes (put int32/float/etc. fields on top)
 
-    PACKED struct Header               //!< Common header for every packet
-    {
-        uint32_t command;              //!< the command of this packet: MSG2_*
-        int32_t source;               //!< source of this command: 0 = server
-        uint32_t streamid;             //!< streamid for this command
-        uint32_t size;                 //!< size of the attached data block
-    };
+#pragma pack(push, 1)
 
-    PACKED struct StreamRegister       //!< Sent from the client to server and vice versa, to broadcast a new stream
-    {
-        int32_t type;                  //!< stream type
-        int32_t status;                //!< initial stream status
-        int32_t origin_sourceid;       //!< origin sourceid
-        int32_t origin_streamid;       //!< origin streamid
-        char name[128];             //!< the truck filename
-        char data[8000];            //!< data used for stream setup
-    };
+struct Header                      //!< Common header for every packet
+{
+    uint32_t command;              //!< the command of this packet: MSG2_*
+    int32_t  source;               //!< source of this command: 0 = server
+    uint32_t streamid;             //!< streamid for this command
+    uint32_t size;                 //!< size of the attached data block
+    uint8_t discardable;           //!< allowed to be discarded?
+};
 
-    PACKED struct TruckStreamRegister {
-        int32_t type;                  //!< stream type
-        int32_t status;                //!< initial stream status
-        int32_t origin_sourceid;       //!< origin sourceid
-        int32_t origin_streamid;       //!< origin streamid
-        char name[128];             //!< the truck filename
-        int32_t bufferSize;            //!< initial stream status
-        char truckconfig[10][60];   //!< truck section configuration
-    };
+struct StreamRegister              //!< Sent from the client to server and vice versa, to broadcast a new stream
+{
+    int32_t type;                  //!< stream type
+    int32_t status;                //!< initial stream status
+    int32_t origin_sourceid;       //!< origin sourceid
+    int32_t origin_streamid;       //!< origin streamid
+    char    name[128];             //!< the actor filename
+    char    data[8000];            //!< data used for stream setup
+};
 
-    PACKED struct StreamUnRegister     //< sent to remove a stream
-    {
-        uint32_t streamid;
-    };
+struct ActorStreamRegister
+{
+    int32_t type;                  //!< stream type
+    int32_t status;                //!< initial stream status
+    int32_t origin_sourceid;       //!< origin sourceid
+    int32_t origin_streamid;       //!< origin streamid
+    char    name[128];             //!< filename
+    int32_t bufferSize;            //!< initial stream status
+    char    actorconfig[10][60];   //!< section configuration
+};
 
-    PACKED struct UserInfo {
-        uint32_t uniqueid;             //!< user unique id
-        int32_t authstatus;           //!< auth status set by server: AUTH_*
-        int32_t slotnum;              //!< slot number set by server
-        int32_t colournum;            //!< colour set by server
+struct StreamUnRegister            //< sent to remove a stream
+{
+    uint32_t streamid;
+};
 
-        char username[RORNET_MAX_USERNAME_LEN]; //!< the nickname of the user
-        char usertoken[40];        //!< user token
-        char serverpassword[40];   //!< server password
-        char language[10];         //!< user's language. For example "de-DE" or "en-US"
-        char clientname[10];       //!< the name and version of the client. For exmaple: "ror" or "gamebot"
-        char clientversion[25];    //!< a version number of the client. For example 1 for RoR 0.35
-        char clientGUID[40];       //!< the clients GUID
-        char sessiontype[10];      //!< the requested session type. For example "normal", "bot", "rcon"
-        char sessionoptions[128];  //!< reserved for future options
-    };
+struct UserInfo
+{
+    uint32_t uniqueid;             //!< user unique id
+    int32_t  authstatus;           //!< auth status set by server: AUTH_*
+    int32_t  slotnum;              //!< slot number set by server
+    int32_t  colournum;            //!< colour set by server
 
-    PACKED struct TruckState           //!< Formerly `oob_t`
-    {
-        int32_t time;                 //!< time data
-        float engine_speed;         //!< engine RPM
-        float engine_force;         //!< engine acceleration
-        float engine_clutch;        //!< the clutch value
-        int32_t engine_gear;          //!< engine gear
-        float hydrodirstate;        //!< the turning direction status
-        float brake;                //!< the brake value
-        float wheelspeed;           //!< the wheel speed value
-        uint32_t flagmask;             //!< flagmask: NETMASK_*
-    };
+    char     username[RORNET_MAX_USERNAME_LEN]; //!< the nickname of the user WIDE CHAR!
+    char     usertoken[40];        //!< user token
+    char     serverpassword[40];   //!< server password
+    char     language[10];         //!< user's language. For example "de-DE" or "en-US"
+    char     clientname[10];       //!< the name and version of the client. For exmaple: "ror" or "gamebot"
+    char     clientversion[25];    //!< a version number of the client. For example 1 for RoR 0.35
+    char     clientGUID[40];       //!< the clients GUID
+    char     sessiontype[10];      //!< the requested session type. For example "normal", "bot", "rcon"
+    char     sessionoptions[128];  //!< reserved for future options
+};
 
-    PACKED struct ServerInfo {
-        char protocolversion[20];   //!< protocol version being used
-        char terrain[128];          //!< terrain name
-        char servername[128];       //!< name of the server
-        uint8_t has_password;          //!< passworded server?
-        char info[4096];            //!< info text
-    };
+struct VehicleState                  //!< Formerly `oob_t`
+{
+    int32_t  time;                 //!< time data
+    float    engine_speed;         //!< engine RPM
+    float    engine_force;         //!< engine acceleration
+    float    engine_clutch;        //!< the clutch value
+    int32_t  engine_gear;          //!< engine gear
+    float    hydrodirstate;        //!< the turning direction status
+    float    brake;                //!< the brake value
+    float    wheelspeed;           //!< the wheel speed value
+    uint32_t flagmask;             //!< flagmask: NETMASK_*
+};
+
+struct ServerInfo
+{
+    char    protocolversion[20];   //!< protocol version being used
+    char    terrain[128];          //!< terrain name
+    char    servername[128];       //!< name of the server
+    uint8_t has_password;          //!< passworded server?
+    char    info[4096];            //!< info text
+};
+
+struct LegacyServerInfo
+{
+    char    protocolversion[20];   //!< protocol version being used
+};
 
 } // namespace RoRnet
 
-#ifdef _MSC_VER
-#   pragma pack(pop)
-#endif
-#undef PACKED
+#pragma pack(pop)

--- a/source/server/broadcaster.h
+++ b/source/server/broadcaster.h
@@ -31,12 +31,12 @@ class SWInetSocket;
 class Sequencer;
 
 struct queue_entry_t {
-    bool is_dropping;
     int type;
     int uid;
+    bool discardable;
     unsigned int streamid;
-    char data[RORNET_MAX_MESSAGE_LENGTH];
     unsigned int datalen;
+    char data[RORNET_MAX_MESSAGE_LENGTH];
 };
 
 void *StartBroadcasterThread(void *);
@@ -54,8 +54,7 @@ public:
 
     void Stop();
 
-    void
-    QueueMessage(int msg_type, int client_id, unsigned int streamid, unsigned int payload_len, const char *payload);
+    void QueueMessage(int msg_type, int client_id, bool discardable, unsigned int streamid, unsigned int payload_len, const char *payload);
 
     bool IsDroppingPackets() const { return m_is_dropping_packets; }
 

--- a/source/server/listener.cpp
+++ b/source/server/listener.cpp
@@ -127,13 +127,14 @@ void Listener::threadstart() {
         //receive a magic
         int type;
         int source;
+        bool discardable;
         unsigned int len;
         unsigned int streamid;
         char buffer[4096];
 
         try {
             // this is the start of it all, it all starts with a simple hello
-            if (Messaging::ReceiveMessage(ts, &type, &source, &streamid, &len, buffer, 256))
+            if (Messaging::ReceiveMessage(ts, &type, &source, &discardable, &streamid, &len, buffer, 256))
                 throw std::runtime_error("ERROR Listener: receiving first message");
 
             // make sure our first message is a hello message
@@ -188,7 +189,7 @@ void Listener::threadstart() {
                 throw std::runtime_error("ERROR Listener: sending version");
 
             //receive user infos
-            if (Messaging::ReceiveMessage(ts, &type, &source, &streamid, &len, buffer, 256)) {
+            if (Messaging::ReceiveMessage(ts, &type, &source, &discardable, &streamid, &len, buffer, 256)) {
                 std::stringstream error_msg;
                 error_msg << "ERROR Listener: receiving user infos\n"
                           << "ERROR Listener: got that: "

--- a/source/server/messaging.cpp
+++ b/source/server/messaging.cpp
@@ -143,6 +143,7 @@ namespace Messaging {
             SWInetSocket *socket,
             int *out_type,
             int *out_source,
+            bool *out_discardable,
             unsigned int *out_stream_id,
             unsigned int *out_payload_len,
             char *out_payload,
@@ -150,6 +151,7 @@ namespace Messaging {
         assert(socket != nullptr);
         assert(out_type != nullptr);
         assert(out_source != nullptr);
+        assert(out_discardable != nullptr);
         assert(out_stream_id != nullptr);
         assert(out_payload != nullptr);
 
@@ -172,6 +174,7 @@ namespace Messaging {
         *out_source = head.source;
         *out_payload_len = head.size;
         *out_stream_id = head.streamid;
+        *out_discardable = head.discardable > 0;
 
         if ((int) head.size >= RORNET_MAX_MESSAGE_LENGTH) {
             Logger::Log(LOG_ERROR, "ReceiveMessage(): payload too long: %d b (max. is %d b)", head.size,

--- a/source/server/messaging.h
+++ b/source/server/messaging.h
@@ -38,6 +38,7 @@ namespace Messaging {
             SWInetSocket *socket,
             int *out_msg_type,
             int *out_client_id,
+            bool *out_discardable,
             unsigned int *out_stream_id,
             unsigned int *out_payload_len,
             char *out_payload,

--- a/source/server/receiver.cpp
+++ b/source/server/receiver.cpp
@@ -65,6 +65,7 @@ void Receiver::Thread() {
     //get the vehicle description
     int type;
     int source;
+    bool discardable;
     unsigned int streamid;
     unsigned int len;
     SWBaseSocket::SWBaseError error;
@@ -80,7 +81,7 @@ void Receiver::Thread() {
     // which is the cause of threads getting blocked
     m_socket->set_timeout(60, 0);
     while (m_is_running) {
-        if (Messaging::ReceiveMessage(m_socket, &type, &source, &streamid, &len, m_dbuffer,
+        if (Messaging::ReceiveMessage(m_socket, &type, &source, &discardable, &streamid, &len, m_dbuffer,
                                       RORNET_MAX_MESSAGE_LENGTH)) {
             m_sequencer->disconnect(m_id, "Game connection closed");
             break;
@@ -98,6 +99,6 @@ void Receiver::Thread() {
             m_sequencer->disconnect(m_id, "Protocol error 3");
             break;
         }
-        m_sequencer->queueMessage(m_id, type, streamid, m_dbuffer, len);
+        m_sequencer->queueMessage(m_id, type, discardable, streamid, m_dbuffer, len);
     }
 }

--- a/source/server/sequencer.cpp
+++ b/source/server/sequencer.cpp
@@ -96,9 +96,9 @@ std::string Client::GetIpAddress() {
     return ip;
 }
 
-void Client::QueueMessage(int msg_type, int client_id, unsigned int stream_id, unsigned int payload_len,
+void Client::QueueMessage(int msg_type, int client_id, bool discardable, unsigned int stream_id, unsigned int payload_len,
                           const char *payload) {
-    m_broadcaster.QueueMessage(msg_type, client_id, stream_id, payload_len, payload);
+    m_broadcaster.QueueMessage(msg_type, client_id, discardable, stream_id, payload_len, payload);
 }
 
 // Yes, this is weird. To be refactored.
@@ -306,7 +306,7 @@ void Sequencer::createClient(SWInetSocket *sock, RoRnet::UserInfo user) {
     memset(info_for_others.usertoken, 0, 40);
     memset(info_for_others.clientGUID, 0, 40);
     for (unsigned int i = 0; i < m_clients.size(); i++) {
-        m_clients[i]->QueueMessage(RoRnet::MSG2_USER_JOIN, client_id, 0, sizeof(RoRnet::UserInfo),
+        m_clients[i]->QueueMessage(RoRnet::MSG2_USER_JOIN, client_id, false, 0, sizeof(RoRnet::UserInfo),
                                    (char *) &info_for_others);
     }
 
@@ -327,7 +327,7 @@ void Sequencer::broadcastUserInfo(int client_id) {
     memset(info_for_others.usertoken, 0, 40);
     memset(info_for_others.clientGUID, 0, 40);
     for (unsigned int i = 0; i < m_clients.size(); i++) {
-        m_clients[i]->QueueMessage(RoRnet::MSG2_USER_INFO, info_for_others.uniqueid, 0, sizeof(RoRnet::UserInfo),
+        m_clients[i]->QueueMessage(RoRnet::MSG2_USER_INFO, info_for_others.uniqueid, false, 0, sizeof(RoRnet::UserInfo),
                                    (char *) &info_for_others);
     }
 }
@@ -414,7 +414,7 @@ void Sequencer::disconnect(int uid, const char *errormsg, bool isError, bool doS
     //notify the others
     int pos = 0;
     for (unsigned int i = 0; i < m_clients.size(); i++) {
-        m_clients[i]->QueueMessage(RoRnet::MSG2_USER_LEAVE, uid, 0, (int) strlen(errormsg), errormsg);
+        m_clients[i]->QueueMessage(RoRnet::MSG2_USER_LEAVE, uid, false, 0, (int) strlen(errormsg), errormsg);
         if (m_clients[i]->user.uniqueid == static_cast<unsigned int>(uid)) {
             pos = i;
         }
@@ -483,14 +483,14 @@ void Sequencer::IntroduceNewClientToAllVehicles(Client *new_client) {
         Client *client = m_clients[i];
         if (client->GetStatus() == Client::STATUS_USED) {
             // new user to all others
-            client->QueueMessage(RoRnet::MSG2_USER_INFO, new_client->user.uniqueid, 0, sizeof(RoRnet::UserInfo),
+            client->QueueMessage(RoRnet::MSG2_USER_INFO, new_client->user.uniqueid, false, 0, sizeof(RoRnet::UserInfo),
                                  (char *) &info_for_others);
 
             // all others to new user
             RoRnet::UserInfo info_for_newcomer = m_clients[i]->user;
             memset(info_for_newcomer.usertoken, 0, 40);
             memset(info_for_newcomer.clientGUID, 0, 40);
-            new_client->QueueMessage(RoRnet::MSG2_USER_INFO, client->user.uniqueid, 0, sizeof(RoRnet::UserInfo),
+            new_client->QueueMessage(RoRnet::MSG2_USER_INFO, client->user.uniqueid, false, 0, sizeof(RoRnet::UserInfo),
                                      (char *) &info_for_newcomer);
 
             Logger::Log(LOG_VERBOSE, " * %d streams registered for user %d", m_clients[i]->streams.size(),
@@ -501,7 +501,7 @@ void Sequencer::IntroduceNewClientToAllVehicles(Client *new_client) {
             for (; itor != endi; ++itor) {
                 Logger::Log(LOG_VERBOSE, "sending stream registration %d:%d to user %d", client->user.uniqueid,
                             itor->first, new_client->user.uniqueid);
-                new_client->QueueMessage(RoRnet::MSG2_STREAM_REGISTER, client->user.uniqueid, itor->first,
+                new_client->QueueMessage(RoRnet::MSG2_STREAM_REGISTER, client->user.uniqueid, false, itor->first,
                                          sizeof(RoRnet::StreamRegister), (char *) &itor->second);
             }
         }
@@ -514,12 +514,12 @@ int Sequencer::sendGameCommand(int uid, std::string cmd) {
 
     if (uid == TO_ALL) {
         for (int i = 0; i < (int) m_clients.size(); i++) {
-            m_clients[i]->QueueMessage(RoRnet::MSG2_GAME_CMD, -1, 0, size, data);
+            m_clients[i]->QueueMessage(RoRnet::MSG2_GAME_CMD, -1, false, 0, size, data);
         }
     } else {
         Client *client = this->FindClientById(static_cast<unsigned int>(uid));
         if (client != nullptr) {
-            client->QueueMessage(RoRnet::MSG2_GAME_CMD, -1, 0, size, data); // ClientId -1: comes from the server
+            client->QueueMessage(RoRnet::MSG2_GAME_CMD, -1, false, 0, size, data); // ClientId -1: comes from the server
         }
     }
     return 0;
@@ -558,7 +558,7 @@ void Sequencer::serverSay(std::string msg, int uid, int type) {
             client->IsReceivingData() &&
             (uid == TO_ALL || ((int) client->user.uniqueid) == uid)) {
             std::string msg_valid = Str::SanitizeUtf8(msg.begin(), msg.end());
-            client->QueueMessage(RoRnet::MSG2_UTF8_CHAT, -1, -1, msg_valid.length(), msg_valid.c_str());
+            client->QueueMessage(RoRnet::MSG2_UTF8_CHAT, -1, false, -1, msg_valid.length(), msg_valid.c_str());
         }
     }
 }
@@ -708,7 +708,7 @@ void Sequencer::streamDebug() {
 }
 
 //this is called by the receivers threads, like crazy & concurrently
-void Sequencer::queueMessage(int uid, int type, unsigned int streamid, char *data, unsigned int len) {
+void Sequencer::queueMessage(int uid, int type, bool discardable, unsigned int streamid, char *data, unsigned int len) {
     MutexLocker scoped_lock(m_clients_mutex);
 
     Client *client = this->FindClientById(static_cast<unsigned int>(uid));
@@ -723,12 +723,12 @@ void Sequencer::queueMessage(int uid, int type, unsigned int streamid, char *dat
             // queue full, inform client
             int drop_state = 1;
             client->drop_state = drop_state;
-            client->QueueMessage(RoRnet::MSG2_NETQUALITY, -1, 0, sizeof(int), (char *) &drop_state);
+            client->QueueMessage(RoRnet::MSG2_NETQUALITY, -1, false, 0, sizeof(int), (char *) &drop_state);
         } else if (!is_dropping && client->drop_state == 1) {
             // queue working better again, inform client
             int drop_state = 0;
             client->drop_state = drop_state;
-            client->QueueMessage(RoRnet::MSG2_NETQUALITY, -1, 0, sizeof(int), (char *) &drop_state);
+            client->QueueMessage(RoRnet::MSG2_NETQUALITY, -1, false, 0, sizeof(int), (char *) &drop_state);
         }
     }
 
@@ -745,8 +745,8 @@ void Sequencer::queueMessage(int uid, int type, unsigned int streamid, char *dat
             if (it == client->streams.end())
                 publishMode = BROADCAST_BLOCK;
             else if (it->second.type == 0) {
-                RoRnet::TruckStreamRegister *reg = (RoRnet::TruckStreamRegister *) &it->second;
-                if ((unsigned int) reg->bufferSize + sizeof(RoRnet::TruckState) != len)
+                RoRnet::ActorStreamRegister *reg = (RoRnet::ActorStreamRegister *) &it->second;
+                if ((unsigned int) reg->bufferSize + sizeof(RoRnet::VehicleState) != len)
                     publishMode = BROADCAST_BLOCK;
             }
         }
@@ -843,7 +843,7 @@ void Sequencer::queueMessage(int uid, int type, unsigned int streamid, char *dat
         RoRnet::StreamRegister *reg = (RoRnet::StreamRegister *) data;
         Client *origin_client = this->FindClientById(reg->origin_sourceid);
         if (origin_client != nullptr) {
-            origin_client->QueueMessage(type, uid, 0, sizeof(RoRnet::StreamRegister), (char *) reg);
+            origin_client->QueueMessage(type, uid, false, 0, sizeof(RoRnet::StreamRegister), (char *) reg);
             Logger::Log(LOG_VERBOSE, "stream registration result for stream %03d:%03d from user %03d: %d",
                         reg->origin_sourceid, reg->origin_streamid, uid, reg->status);
         }
@@ -1034,7 +1034,7 @@ void Sequencer::queueMessage(int uid, int type, unsigned int streamid, char *dat
         if (dest_client != nullptr) {
             char *chatmsg = data + sizeof(int);
             int chatlen = len - sizeof(int);
-            dest_client->QueueMessage(RoRnet::MSG2_UTF8_PRIVCHAT, uid, streamid, chatlen, chatmsg);
+            dest_client->QueueMessage(RoRnet::MSG2_UTF8_PRIVCHAT, uid, false, streamid, chatlen, chatmsg);
             publishMode = BROADCAST_BLOCK;
         }
     } else if (type == RoRnet::MSG2_GAME_CMD) {
@@ -1093,7 +1093,7 @@ void Sequencer::queueMessage(int uid, int type, unsigned int streamid, char *dat
                 if (curr_client->GetStatus() == Client::STATUS_USED && curr_client->IsReceivingData() &&
                     (curr_client != client || toAll)) {
                     curr_client->streams_traffic[streamid].bandwidthOutgoing += len;
-                    curr_client->QueueMessage(type, client->user.uniqueid, streamid, len, data);
+                    curr_client->QueueMessage(type, client->user.uniqueid, discardable, streamid, len, data);
                 }
             }
         } else if (publishMode == BROADCAST_AUTHED) {
@@ -1103,7 +1103,7 @@ void Sequencer::queueMessage(int uid, int type, unsigned int streamid, char *dat
                 if (curr_client->GetStatus() == Client::STATUS_USED && curr_client->IsReceivingData() &&
                     (curr_client != client) && (client->user.authstatus & RoRnet::AUTH_ADMIN)) {
                     curr_client->streams_traffic[streamid].bandwidthOutgoing += len;
-                    curr_client->QueueMessage(type, client->user.uniqueid, streamid, len, data);
+                    curr_client->QueueMessage(type, client->user.uniqueid, discardable, streamid, len, data);
                 }
             }
         }

--- a/source/server/sequencer.h
+++ b/source/server/sequencer.h
@@ -101,8 +101,7 @@ public:
 
     void Disconnect();
 
-    void
-    QueueMessage(int msg_type, int client_id, unsigned int stream_id, unsigned int payload_len, const char *payload);
+    void QueueMessage(int msg_type, int client_id, bool discardable, unsigned int stream_id, unsigned int payload_len, const char *payload);
 
     void NotifyAllVehicles(Sequencer *sequencer);
 
@@ -166,7 +165,7 @@ public:
     //! queue client for disconenct
     void disconnect(int pos, const char *error, bool isError = true, bool doScriptCallback = true);
 
-    void queueMessage(int pos, int type, unsigned int streamid, char *data, unsigned int len);
+    void queueMessage(int uid, int type, bool discardable, unsigned int streamid, char *data, unsigned int len);
 
     void enableFlow(int id);
 


### PR DESCRIPTION
The existing soft/hard limit for the broadcaster packet queue size was completely inadequate to solve any kind of packet congestion.

No only did it drop packets that must not be dropped (CHARACTER_CMD_ATTACH, CHARACTER_CMD_DETACH, ...), it also did not drop enough packets to prevent severe desync on slow connections.

The new solution automatically discards outdated streamdata (before relaying it to the clients).

The RoRnet.h is a direct copy from https://github.com/RigsOfRods/rigs-of-rods/tree/master/source/main/network/RoRnet.h

Using 'pragma pack' probably already was a pretty bad idea in the first place, but using different packing methods on client and server definitly shot the bird.

Requires: https://github.com/RigsOfRods/rigs-of-rods/pull/2216