### PR TITLE
🐛 Hotfixed broken serverpassword / usertoken logic

### DIFF
--- a/source/server/listener.cpp
+++ b/source/server/listener.cpp
@@ -208,13 +208,13 @@ void Listener::threadstart() {
 
             // authenticate
             std::string nickname = Str::SanitizeUtf8(user->username);
-            user->authstatus = m_sequencer->AuthorizeNick(std::string(user->usertoken), nickname);
+            user->authstatus = m_sequencer->AuthorizeNick(std::string(user->usertoken, 40), nickname);
             strncpy(user->username, nickname.c_str(), RORNET_MAX_USERNAME_LEN);
 
             if (Config::isPublic()) {
                 Logger::Log(LOG_DEBUG, "password login: %s == %s?",
                             Config::getPublicPassword().c_str(),
-                            user->serverpassword);
+                            std::string(user->serverpassword, 40).c_str());
                 if (strncmp(Config::getPublicPassword().c_str(), user->serverpassword, 40)) {
                     Messaging::SendMessage(ts, RoRnet::MSG2_WRONG_PW, 0, 0, 0, 0);
                     throw std::runtime_error("ERROR Listener: wrong password");

--- a/source/server/sequencer.cpp
+++ b/source/server/sequencer.cpp
@@ -267,7 +267,7 @@ void Sequencer::createClient(SWInetSocket *sock, RoRnet::UserInfo user) {
     char buf[3000];
     if (strlen(user.usertoken) > 0)
         sprintf(buf, "New client: %s (%s), using %s %s, with token %s", user.username, user.language, user.clientname,
-                user.clientversion, std::string(user.usertoken).substr(0, 40).c_str());
+                user.clientversion, std::string(user.usertoken, 40).c_str());
     else
         sprintf(buf, "New client: %s (%s), using %s %s, without token", user.username, user.language, user.clientname,
                 user.clientversion);
@@ -398,7 +398,7 @@ void Sequencer::disconnect(int uid, const char *errormsg, bool isError, bool doS
 
     // send an event if user is rankend and if we are a official server
     if (m_auth_resolver && (client->user.authstatus & RoRnet::AUTH_RANKED)) {
-        m_auth_resolver->sendUserEvent(client->user.usertoken, (isError ? "crash" : "leave"),
+        m_auth_resolver->sendUserEvent(std::string(client->user.usertoken, 40), (isError ? "crash" : "leave"),
                                        Str::SanitizeUtf8(client->user.username), "");
     }
 
@@ -806,7 +806,7 @@ void Sequencer::queueMessage(int uid, int type, unsigned int streamid, char *dat
 
                 // send an event if user is rankend and if we are a official server
                 if (m_auth_resolver && (client->user.authstatus & RoRnet::AUTH_RANKED))
-                    m_auth_resolver->sendUserEvent(client->user.usertoken, std::string("newvehicle"),
+                    m_auth_resolver->sendUserEvent(std::string(client->user.usertoken, 40), std::string("newvehicle"),
                                                    std::string(reg->name), std::string());
 
                 // Notify the user about the vehicle limit


### PR DESCRIPTION
`UserInfo::usertoken` and `UserInfo::serverpassword` are not null-terminated ...