### PR TITLE
Spam filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,28 @@ logverbosity = 1
 ## Debug: Time in seconds, default 60.
 # heartbeat-interval =
 
+## Spam filter: time span (in seconds) to check for repeated messages.
+## Default: 0 = disables spam filter.
+# spamfilter-msg-interval =
+
+## Spam filter: minimum number of repeated messages (within defined interval) to consider spam and penalize the player.
+## Default: 0 = disables spam filter.
+# spamfilter-msg-count =
+
+## Spam filter: Gag time awarded for each detected spam message.
+## Default: 10 seconds.
+# spamfilter-gag-duration = 10
 ```
 
 Notes:
 By default, if neither `-lan` nor `-inet` is used the server will try to register at the master server and fall back to LAN mode in case it fails.
+
+## Chat spam filtering
+
+The spam filter operates by caching player's chat messages for a defined period of time (see config file) and looking for repeated messages (see config file).
+If spam is detected, the player is silenced for some time (see config file) and server responds (to each message) `"You are gagged. Time remaining: N seconds."`.
+The spam detection is continuous, and for each new spam message, the gag time is increased by the configured value.
+Finally, if player behaves, the gag lapses and server displays (upon first passing message) `"Your gag has expired. Chat nicely!"`.
 
 ## Vehicle spawn limits
 

--- a/contrib/example-config.cfg
+++ b/contrib/example-config.cfg
@@ -98,3 +98,15 @@ rulesfile = /etc/rorserver/simple.rules
 
 ## Debug: Master serverlist path. Leave blank or enter path, i.e. `/xror/mp-portal`
 # serverlist-path = 
+
+## Spam filter: time span (in seconds) to check for repeated messages.
+## Default: 0 = disables spam filter.
+# spamfilter-msg-interval =
+
+## Spam filter: minimum number of repeated messages (within defined interval) to consider spam and penalize the player.
+## Default: 0 = disables spam filter.
+# spamfilter-msg-count =
+
+## Spam filter: Gag time awarded for each detected spam message.
+## Default: 10 seconds.
+# spamfilter-gag-duration = 10

--- a/source/server/config.h
+++ b/source/server/config.h
@@ -105,6 +105,11 @@ namespace Config {
     unsigned int getMaxVehicles();
     int getSpawnIntervalSec();
     int getMaxSpawnRate();
+
+    // Spam filter
+    int getSpamFilterMsgIntervalSec();
+    int getSpamFilterMsgCount();
+    int getSpamFilterGagDurationSec();
 //!@}
 
 //! setter functions
@@ -155,6 +160,11 @@ namespace Config {
     void setMaxVehicles(unsigned int num);
     void setSpawnIntervalSec(int sec);
     void setMaxSpawnRate(int num);
+
+    // Spam filter
+    void setSpamFilterMsgIntervalSec(int sec);
+    void setSpamFilterMsgCount(int count);
+    void setSpamFilterGagDurationSec(int sec);
 //!@}
 
 } // namespace Config

--- a/source/server/sequencer.h
+++ b/source/server/sequencer.h
@@ -26,6 +26,7 @@ along with Foobar. If not, see <http://www.gnu.org/licenses/>.
 #include "mutexutils.h"
 #include "broadcaster.h"
 #include "receiver.h"
+#include "spamfilter.h"
 #include "json/json.h"
 
 #ifdef WITH_ANGELSCRIPT
@@ -92,6 +93,7 @@ struct stream_traffic_t {
 
 class Client {
 public:
+
     enum Status {
         STATUS_FREE = 0,
         STATUS_BUSY = 1,
@@ -126,6 +128,10 @@ public:
 
     std::string GetUsername() const { return Str::SanitizeUtf8(user.username); }
 
+    SpamFilter& GetSpamFilter() { return m_spamfilter; }
+
+    Sequencer* GetSequencer() {  }
+
     RoRnet::UserInfo user;  //!< user information
 
     int drop_state;             // dropping outgoing packets?
@@ -139,7 +145,8 @@ private:
     Receiver m_receiver;
     Broadcaster m_broadcaster;
     Status m_status;
-    Sequencer *m_sequencer;
+    SpamFilter m_spamfilter;
+    Sequencer* m_sequencer;
     bool m_is_receiving_data;
     bool m_is_initialized;
     std::vector<std::chrono::system_clock::time_point> m_stream_reg_timestamps; //!< To limit spawn rate
@@ -214,7 +221,7 @@ public:
 
     void UpdateMinuteStats();
 
-    void serverSay(std::string msg, int notto = -1, int type = 0);
+    void serverSay(std::string msg, int uid = -1, int type = 0);
 
     int sendGameCommand(int uid, std::string cmd);
 

--- a/source/server/spamfilter.cpp
+++ b/source/server/spamfilter.cpp
@@ -1,0 +1,98 @@
+/*
+This file is part of "Rigs of Rods Server" (Relay mode)
+
+Copyright 2007   Pierre-Michel Ricordel
+Copyright 2014+  Rigs of Rods Community
+
+"Rigs of Rods Server" is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+"Rigs of Rods Server" is distributed in the hope that it will
+be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Rigs of Rods Server. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "spamfilter.h"
+
+#include "config.h"
+#include "logger.h"
+#include "sequencer.h"
+
+// --------------------------------
+// Static functions
+
+bool SpamFilter::IsActive()
+{
+    return (Config::getSpamFilterMsgIntervalSec() > 0) &&
+           (Config::getSpamFilterMsgCount() > 0);
+}
+
+void SpamFilter::CheckConfig()
+{
+    if (SpamFilter::IsActive()) {
+        Logger::Log(LOG_INFO, "spam filter: active, %d msg/%d sec -> %d sec gag",
+            Config::getSpamFilterMsgCount(), Config::getSpamFilterMsgIntervalSec(),
+            Config::getSpamFilterGagDurationSec());
+    } else {
+        Logger::Log(LOG_INFO, "spam filter: disabled");
+    }
+}
+
+// --------------------------------
+// Instance functions
+
+SpamFilter::SpamFilter(Sequencer* seq, Client* c)
+    : m_sequencer(seq)
+    , m_client(c)
+{}
+
+bool SpamFilter::CheckForSpam(std::string const& msg) {
+    const TimePoint now = std::chrono::system_clock::now();
+    const std::chrono::seconds cache_expiry(Config::getSpamFilterMsgIntervalSec());
+
+    // Count message occurences in cache
+    auto itor = m_msg_cache.begin();
+    int num_occurs = 0;
+    while (itor != m_msg_cache.end()) {
+        if (itor->first + cache_expiry < now) { // Purge expired messages
+            itor = m_msg_cache.erase(itor);
+        } else {
+            if (msg == itor->second) { // Full, case-sensitive match -- proof of concept
+                num_occurs++;
+            }
+            ++itor;
+        }
+    }
+
+    // Add this message to cache
+    m_msg_cache.push_back(CacheMsg(now, msg));
+
+    // Update gag
+    if (num_occurs > Config::getSpamFilterMsgCount()) {
+        if (!m_gagged) {
+            m_gag_expiry = now;
+        }
+        m_gagged = true;
+        m_gag_expiry += std::chrono::seconds(Config::getSpamFilterGagDurationSec());
+    } else if (m_gagged && m_gag_expiry < now) {
+        m_gagged = false;
+        m_sequencer->serverSay("Your gag has expired. Chat nicely!", m_client->GetUserId(), FROM_SERVER);
+    }
+
+    // Notify player
+    if (m_gagged) {
+        char msg[200];
+        std::chrono::system_clock::duration time_left = m_gag_expiry - now;
+        std::chrono::seconds seconds_left = std::chrono::duration_cast<std::chrono::seconds>(time_left);
+        snprintf(msg, 200, "You are gagged. Time remaining: %d seconds.", (int)seconds_left.count());
+        m_sequencer->serverSay(msg, m_client->GetUserId(), FROM_SERVER);
+    }
+
+    return m_gagged;
+}

--- a/source/server/spamfilter.h
+++ b/source/server/spamfilter.h
@@ -1,0 +1,53 @@
+/*
+This file is part of "Rigs of Rods Server" (Relay mode)
+
+Copyright 2007   Pierre-Michel Ricordel
+Copyright 2014+  Rigs of Rods Community
+
+"Rigs of Rods Server" is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+"Rigs of Rods Server" is distributed in the hope that it will
+be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Rigs of Rods Server. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+/// @file Simple spam-filter for chat
+/// @author Petr Ohlidal, 2020
+
+#include "prerequisites.h"
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+/// One instance per `Client` (see 'sequencer.h')
+class SpamFilter
+{
+public:
+    typedef std::chrono::system_clock::time_point  TimePoint; // Shorter code
+    typedef std::pair<TimePoint, std::string>  CacheMsg;
+
+    static bool IsActive();
+    static void CheckConfig();
+
+    SpamFilter(Sequencer* seq, Client* c);
+
+    bool CheckForSpam(std::string const& msg); //!< True = it's spam!
+
+private:
+    std::vector<CacheMsg>  m_msg_cache;
+    TimePoint              m_gag_expiry;
+    Client*                m_client;
+    Sequencer*             m_sequencer;
+    bool                   m_gagged = false;
+};
+


### PR DESCRIPTION
Following are excerpts from README and example-config

## About

The spam filter operates by caching player's chat messages for a defined period of time (see config file) and looking for repeated messages (see config file).
If spam is detected, the player is silenced for some time (see config file) and server responds (to each message) `"You are gagged. Time remaining: N seconds."`.
The spam detection is continuous, and for each new spam message, the gag time is increased by the configured value.
Finally, if player behaves, the gag lapses and server displays (upon first passing message) `"Your gag has expired. Chat nicely!"`.

## Config
```
## Spam filter: time span (in seconds) to check for repeated messages.
## Default: 0 = disables spam filter.
# spamfilter-msg-interval =

## Spam filter: minimum number of repeated messages (within defined interval) to consider spam and penalize the player.
## Default: 0 = disables spam filter.
# spamfilter-msg-count =

## Spam filter: Gag time awarded for each detected spam message.
## Default: 10 seconds.
# spamfilter-gag-duration = 10
```
