### PR TITLE
Added vehicle spawn rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ mode = inet
 ## syntax: vehicles = <number greater than 0>
 # vehiclelimit = 5
 
+## The maximum rate (num. spawns per interval) of spawning new vehicles.
+## Default: 0 = not limited
+# vehicle-max-spawn-rate = 
+
+## The time interval (in seconds) to evaluate max. spawn rate of new vehicles.
+## Default: 0 = spawn rate not limited
+# vehicle-spawn-interval =
+
 ## The location of the message of the day file
 ## syntax: motdfile = <path-to-file>
 motdfile = /etc/rorserver/simple.motd
@@ -147,6 +155,17 @@ logverbosity = 1
 
 Notes:
 By default, if neither `-lan` nor `-inet` is used the server will try to register at the master server and fall back to LAN mode in case it fails.
+
+## Vehicle spawn limits
+
+Server can limit the total number of vehicles the player spawns, as well as the rate at which they spawn.
+  Exceeding the limits results in auto-kick.
+
+The maximum vehicle count is specified in config file or command line.
+  Player receives informational messages about the limit and current usage.
+
+The spawn rate is specified in config file as a time interval and maximum number of spawns within the interval.
+  When player uses 70% of the limit they begin getting warning messages.
 
 ## Bandwidth used by the server:
 The RoR server uses large amounts of bandwidth. The general formula to compute bandwidth is:  

--- a/contrib/example-config.cfg
+++ b/contrib/example-config.cfg
@@ -37,6 +37,14 @@ mode = inet
 ## syntax: vehicles = <number greater than 0>
 # vehiclelimit = 5
 
+## The maximum rate (num. spawns per interval) of spawning new vehicles.
+## Default: 0 = not limited
+# vehicle-max-spawn-rate = 
+
+## The time interval (in seconds) to evaluate max. spawn rate of new vehicles.
+## Default: 0 = spawn rate not limited
+# vehicle-spawn-interval =
+
 ## The location of the message of the day file
 ## syntax: motdfile = <path-to-file>
 motdfile = /etc/rorserver/simple.motd

--- a/source/server/config.cpp
+++ b/source/server/config.cpp
@@ -62,7 +62,6 @@ static std::string s_serverlist_host("api.rigsofrods.org");
 static std::string s_serverlist_path("");
 static std::string s_resourcedir(RESOURCE_DIR);
 
-static unsigned int s_max_vehicles(20);
 static unsigned int s_listen_port(0);
 static unsigned int s_max_clients(16);
 static unsigned int s_heartbeat_retry_count(5);
@@ -73,6 +72,11 @@ static bool s_print_stats(false);
 static bool s_foreground(false);
 static bool s_show_version(false);
 static bool s_show_help(false);
+
+// Vehicle spawn limits
+static size_t s_max_vehicles(20);
+static int    s_spawn_interval_sec(0);
+static int    s_max_spawn_rate(0);
 
 static ServerType s_server_mode(SERVER_AUTO);
 
@@ -313,8 +317,6 @@ namespace Config {
 
     const std::string &getRulesFile() { return s_rulesfile; }
 
-    unsigned int getMaxVehicles() { return s_max_vehicles; }
-
     const std::string &getOwner() { return s_owner; }
 
     const std::string &getWebsite() { return s_website; }
@@ -338,6 +340,10 @@ namespace Config {
     unsigned int GetHeartbeatRetrySeconds() { return s_heartbeat_retry_seconds; }
 
     unsigned int GetHeartbeatIntervalSec() { return s_heartbeat_interval_sec; }
+
+    unsigned int getMaxVehicles() { return s_max_vehicles; }
+    int getSpawnIntervalSec() { return s_spawn_interval_sec; }
+    int getMaxSpawnRate() { return s_max_spawn_rate; }
 
 
     bool setScriptName(const std::string &name) {
@@ -398,6 +404,10 @@ namespace Config {
     void setBlacklistFile(const std::string &file) { s_blacklistfile = file; }
 
     void setMaxVehicles(unsigned int num) { s_max_vehicles = num; }
+
+    void setSpawnIntervalSec(int sec) { s_spawn_interval_sec = sec; }
+
+    void setMaxSpawnRate(int num) { s_max_spawn_rate = num; }
 
     void setOwner(const std::string &owner) { s_owner = owner; }
 
@@ -471,7 +481,6 @@ namespace Config {
         else if (strcmp(key, "motdfile") == 0) { setMOTDFile(VAL_STR (value)); }
         else if (strcmp(key, "rulesfile") == 0) { setRulesFile(VAL_STR (value)); }
         else if (strcmp(key, "blacklistfile") == 0) { setBlacklistFile(VAL_STR(value)); }
-        else if (strcmp(key, "vehiclelimit") == 0) { setMaxVehicles(VAL_INT (value)); }
         else if (strcmp(key, "owner") == 0) { setOwner(VAL_STR (value)); }
         else if (strcmp(key, "website") == 0) { setWebsite(VAL_STR (value)); }
         else if (strcmp(key, "irc") == 0) { setIRC(VAL_STR (value)); }
@@ -481,6 +490,10 @@ namespace Config {
         else if (strcmp(key, "verbosity") == 0) { Logger::SetLogLevel(LOGTYPE_DISPLAY, (LogLevel) VAL_INT(value)); }
         else if (strcmp(key, "logverbosity") == 0) { Logger::SetLogLevel(LOGTYPE_FILE, (LogLevel) VAL_INT(value)); }
         else if (strcmp(key, "heartbeat-interval") == 0) { setHeartbeatIntervalSec(VAL_INT(value)); }
+        // Vehicle spawn limits
+        else if (strcmp(key, "vehiclelimit") == 0) { setMaxVehicles(VAL_INT (value)); }
+        else if (strcmp(key, "vehicle-spawn-interval") == 0) { setSpawnIntervalSec(VAL_INT (value)); }
+        else if (strcmp(key, "vehicle-max-spawn-rate") == 0) { setMaxSpawnRate(VAL_INT (value)); }
         else {
             Logger::Log(LOG_WARN, "Unknown key '%s' (value: '%s') in config file.", key, value);
         }

--- a/source/server/config.h
+++ b/source/server/config.h
@@ -77,8 +77,6 @@ namespace Config {
 
     const std::string &getBlacklistFile();
 
-    unsigned int getMaxVehicles();
-
     const std::string &getOwner();
 
     const std::string &getWebsite();
@@ -102,6 +100,11 @@ namespace Config {
     bool GetShowHelp();
 
     bool GetShowVersion();
+
+    // Vehicle spawn limits
+    unsigned int getMaxVehicles();
+    int getSpawnIntervalSec();
+    int getMaxSpawnRate();
 //!@}
 
 //! setter functions
@@ -140,8 +143,6 @@ namespace Config {
 
     void setBlacklistFile(const std::string &blacklistFile);
 
-    void setMaxVehicles(unsigned int num);
-
     void setOwner(const std::string &owner);
 
     void setWebsite(const std::string &website);
@@ -149,6 +150,11 @@ namespace Config {
     void setIRC(const std::string &irc);
 
     void setVoIP(const std::string &voip);
+
+    // Vehicle spawn limits
+    void setMaxVehicles(unsigned int num);
+    void setSpawnIntervalSec(int sec);
+    void setMaxSpawnRate(int num);
 //!@}
 
 } // namespace Config


### PR DESCRIPTION
below are excerpts from README and example-config

## Readme

Server can limit the total number of vehicles the player spawns, as well as the rate at which they spawn.  Exceeding the limits results in auto-kick.

The maximum vehicle count is specified in config file or command line.  Player receives informational messages about the limit and current usage.

The spawn rate is specified in config file as a time interval and maximum number of spawns within the interval.  When player uses 70% of the limit they begin getting warning messages.

## Config

```
## The maximum amount of vehicles a player is allowed to have
## Vehicles, i.e. loads, trailers, planes, cars, trucks, boats, etc.
## syntax: vehicles = <number greater than 0>
# vehiclelimit = 5

## The maximum rate (num. spawns per interval) of spawning new vehicles.
## Default: 0 = not limited
# vehicle-max-spawn-rate = 

## The time interval (in seconds) to evaluate max. spawn rate of new vehicles.
## Default: 0 = spawn rate not limited
# vehicle-spawn-interval =
```