### PR TITLE
Block streams with empty vehicle name

### DIFF
--- a/source/server/sequencer.cpp
+++ b/source/server/sequencer.cpp
@@ -826,6 +826,21 @@ void Sequencer::queueMessage(int uid, int type, unsigned int streamid, char *dat
                     Config::getMaxSpawnRate(), Config::getSpawnIntervalSec());
             QueueClientForDisconnect(client->user.uniqueid, sayMsg, false);
             publishMode = BROADCAST_BLOCK; // drop
+        } else if (reg->type == STREAM_REG_TYPE_VEHICLE && !Utils::isValidVehicleFileName(reg->name)) {
+            // This user spawned vehicle with empty or malformed name, we drop the stream and then disconnect the user
+            Logger::Log(LOG_INFO, "%s(%d) spawned vehicle with empty/malformed name. Stream dropped, user kicked.",
+                        client->GetUsername().c_str(), client->user.uniqueid);
+
+            // broadcast a general message that this user was auto-kicked
+            char sayMsg[300] = "";
+            snprintf(sayMsg, 300, "%s was auto-kicked for spawning vehicle with empty/malformed name", client->GetUsername().c_str());
+            serverSay(sayMsg, TO_ALL, FROM_SERVER);
+
+            // disconnect the user with a message
+            snprintf(sayMsg, 300, "You were auto-kicked for spawning invalid vehicle");
+
+            QueueClientForDisconnect(client->user.uniqueid, sayMsg, false);
+            publishMode = BROADCAST_BLOCK; // drop
         } else {
             publishMode = BROADCAST_NORMAL;
 

--- a/source/server/utils.cpp
+++ b/source/server/utils.cpp
@@ -104,6 +104,25 @@ namespace Utils {
         return g == 0;
     }
 
+    // For checking STREAM_REGISTER messages
+    bool isValidVehicleFileName(std::string name)
+    {
+        if (name == "")
+            return false;
+
+        bool all_spaces = true; // We accept spaces in the name, but not name with only spaces.
+        for (char c: name)
+        {
+            if (!isprint(c))
+                return false; // Unacceptable character
+
+            if (!isspace(c))
+                all_spaces = false;
+        }
+
+        return !all_spaces;
+    }
+
 } // namespace Utils
 
 using namespace std;

--- a/source/server/utils.h
+++ b/source/server/utils.h
@@ -37,6 +37,10 @@ namespace Utils {
 
     bool IsEmptyFile(std::ifstream& f);
 
+    // For checking STREAM_REGISTER messages
+    bool isValidVehicleFileName(std::string name);
+
+
 } // namespace Utils
 
 void tokenize(const std::string &str,


### PR DESCRIPTION
Non English characters in truck filename (example `ωesperado.truck`) produce empty truck name registration in rorserver.

Fixes https://github.com/RigsOfRods/ror-server/issues/96