### PR TITLE
SocketW: Error handling is now thread safe and never `exit()`s.

### DIFF
--- a/dependencies/socketw/sw_base.h
+++ b/dependencies/socketw/sw_base.h
@@ -30,9 +30,7 @@
 //
 // Default is throw_errors == false and verbose == true
 void sw_setThrowMode(bool throw_errors);
-void sw_setVerboseMode(bool verbose);
 bool sw_getThrowMode(void);
-bool sw_getVerboseMode(void);
 
 
 // Abstract base class for streaming sockets
@@ -151,10 +149,6 @@ public:
 	// and others that use those, i.e. all frecvmsg().
 	void set_timeout(Uint32 sec, Uint32 usec){ tsec = sec, tusec = usec; }
 	
-	// Error handling
-	virtual void print_error(); //prints the last error if any to stderr
-	virtual std::string get_error(){return error_string;}  //returns a human readable error string
-
 protected:
 	// get a new socket if myfd < 0
 	virtual void get_socket()=0;
@@ -178,9 +172,6 @@ protected:
 
 	// our socket descriptor
 	int myfd;
-	
-	// last error
-	std::string error_string;
 
 	// data for fsend
 	bool fsend_ready;


### PR DESCRIPTION
I've suspected SocketW of causing issues for years, but only today I actually went to check it's source code. The last straw were 2 new stack-corruption backtraces I received the day before, both pointing to SocketW. And guess what - in about 10 minutes I found an obvious multi-threading hazzard.

---

**Code changes:**

* Removed variable `SWBaseSocket::error_string` which was written on any error and read on error in `disconnect()`, all without synchronization. This is a problem in Rigs of Rods server which uses each client socket from 2 threads: receiver and broadcaster.
* Function `SWBaseSocket::set_error()` was modified to only fill the supplied SWBaseError object, without touching anything in the SWBaseSocket object. Also, the function won't shut down the whole program with `exit()` anymore.
* "verbose mode" was removed completely.