### PR TITLE
Fixed segfault on exit when scripts loaded

### DIFF
--- a/source/server/ScriptEngine.cpp
+++ b/source/server/ScriptEngine.cpp
@@ -633,7 +633,10 @@ int ScriptEngine::framestep(float dt) {
     }
 
     // Collect garbage
-    engine->GarbageCollect(asGC_ONE_STEP);
+    if (!exit)
+    {
+        engine->GarbageCollect(asGC_ONE_STEP);
+    }
 
     return 0;
 }


### PR DESCRIPTION
```
Thread 8 "rorserver" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffe6ffd700 (LWP 17556)]
0x00000000000001d0 in ?? ()
#0  0x00000000000001d0 in ?? ()
#1  0x000055555559c610 in ScriptEngine::framestep (this=this@entry=0x5555558d7e30, dt=dt@entry=200) at /home/administrator/rorserver/source_243/source/server/ScriptEngine.cpp:636
#2  0x000055555559c73a in ScriptEngine::timerLoop (this=0x5555558d7e30) at /home/administrator/rorserver/source_243/source/server/ScriptEngine.cpp:837
#3  0x000055555559c759 in s_sethreadstart (se=<optimized out>) at /home/administrator/rorserver/source_243/source/server/ScriptEngine.cpp:76
#4  0x00007ffff79b26db in start_thread (arg=0x7fffe6ffd700) at pthread_create.c:463
#5  0x00007ffff6d9ca3f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[New Thread 0x7ffff6c7a700 (LWP 6901)]
[New Thread 0x7ffff6479700 (LWP 6902)]
```