### PR TITLE
New commands !banvehicle !unbanvehicle and !vehiclebans

### DIFF
--- a/contrib/example-config.cfg
+++ b/contrib/example-config.cfg
@@ -57,6 +57,14 @@ authfile = /etc/rorserver/simple.auth
 ## syntax: rulesfile = <path-to-file>
 rulesfile = /etc/rorserver/simple.rules
 
+## Database of banned users (read-write access needed).
+## syntax: blacklistfile = <path-to-file>
+# blacklistfile = /etc/rorserver/server.blacklist
+
+## Database of banned vehicles (read-write access needed).
+## syntax: truckblacklistfile = <path-to-file>
+# truckblacklistfile = /etc/rorserver/truck.blacklist
+
 ## The owner of this server. This can be you, your organization or anything else.
 ## syntax: owner = <name|organisation>
 # owner = 

--- a/source/protocol/rornet.h
+++ b/source/protocol/rornet.h
@@ -129,7 +129,7 @@ struct Header                      //!< Common header for every packet
 
 struct StreamRegister              //!< Sent from the client to server and vice versa, to broadcast a new stream
 {
-    int32_t type;                  //!< stream type
+    int32_t type;                  //!< stream type (0 = Actor, 1 = Character, 3 = ChatSystem)
     int32_t status;                //!< initial stream status
     int32_t origin_sourceid;       //!< origin sourceid
     int32_t origin_streamid;       //!< origin streamid

--- a/source/protocol/rornet.h
+++ b/source/protocol/rornet.h
@@ -25,12 +25,16 @@
 
 namespace RoRnet {
 
-#define RORNET_MAX_PEERS            64     //!< maximum clients connected at the same time
-#define RORNET_MAX_MESSAGE_LENGTH   8192   //!< maximum size of a RoR message. 8192 bytes = 8 kibibytes
-#define RORNET_LAN_BROADCAST_PORT   13000  //!< port used to send the broadcast announcement in LAN mode
-#define RORNET_MAX_USERNAME_LEN     40     //!< port used to send the broadcast announcement in LAN mode
+#define RORNET_MAX_PEERS             64     //!< maximum clients connected at the same time
+#define RORNET_MAX_MESSAGE_LENGTH    8192   //!< maximum size of a RoR message. 8192 bytes = 8 kibibytes
+#define RORNET_LAN_BROADCAST_PORT    13000  //!< port used to send the broadcast announcement in LAN mode
+#define RORNET_MAX_USERNAME_LEN      40     //!< port used to send the broadcast announcement in LAN mode
 
-#define RORNET_VERSION              "RoRnet_2.43"
+#define RORNET_VERSION               "RoRnet_2.43"
+
+#define RORNET_STREAM_TYPE_VEHICLE   0
+#define RORNET_STREAM_TYPE_CHARACTER 1
+#define RORNET_STREAM_TYPE_NETCHAT   3
 
 enum MessageType
 {
@@ -129,7 +133,7 @@ struct Header                      //!< Common header for every packet
 
 struct StreamRegister              //!< Sent from the client to server and vice versa, to broadcast a new stream
 {
-    int32_t type;                  //!< stream type (0 = Actor, 1 = Character, 3 = ChatSystem)
+    int32_t type;                  //!< stream type (RORNET_STREAM_TYPE_*)
     int32_t status;                //!< initial stream status
     int32_t origin_sourceid;       //!< origin sourceid
     int32_t origin_streamid;       //!< origin streamid

--- a/source/server/config.cpp
+++ b/source/server/config.cpp
@@ -75,9 +75,9 @@ static bool s_show_version(false);
 static bool s_show_help(false);
 
 // Vehicle spawn limits
-static size_t s_max_vehicles(20);
-static int    s_spawn_interval_sec(0);
-static int    s_max_spawn_rate(0);
+static int s_max_vehicles(20);
+static int s_spawn_interval_sec(0);
+static int s_max_spawn_rate(0);
 
 static ServerType s_server_mode(SERVER_AUTO);
 
@@ -348,7 +348,7 @@ namespace Config {
 
     unsigned int GetHeartbeatIntervalSec() { return s_heartbeat_interval_sec; }
 
-    unsigned int getMaxVehicles() { return s_max_vehicles; }
+    int getMaxVehicles() { return s_max_vehicles; }
 
     int getSpawnIntervalSec() { return s_spawn_interval_sec; }
 

--- a/source/server/config.cpp
+++ b/source/server/config.cpp
@@ -55,6 +55,7 @@ static std::string s_authfile("server.auth");
 static std::string s_motdfile("server.motd");
 static std::string s_rulesfile("server.rules");
 static std::string s_blacklistfile("server.blacklist");
+static std::string s_truckblacklistfile("truck.blacklist");
 static std::string s_owner;
 static std::string s_website;
 static std::string s_irc;
@@ -94,41 +95,42 @@ namespace Config {
                 "Usage: rorserver [OPTIONS]\n"
                         "[OPTIONS] can be in Un*x `--help` or windows `/help` notation\n"
                         "\n"
-                        " -config-file (-c) <INI file> Loads the configuration from a file\n"
-                        " -name <name>                 Name of the server, no spaces, only\n"
-                        "                              [a-z,0-9,A-Z]\n"
-                        " -terrain <mapname>           Map name (defaults to 'any')\n"
-                        " -max-clients|speed <clients> Maximum clients allowed\n"
-                        " -lan|inet                    Private or public server (defaults to inet)\n"
+                        " -config-file (-c) <INI file>              Loads the configuration from a file\n"
+                        " -name <name>                              Name of the server, no spaces, only\n"
+                        "                                           [a-z,0-9,A-Z]\n"
+                        " -terrain <mapname>                        Map name (defaults to 'any')\n"
+                        " -max-clients|speed <clients>              Maximum clients allowed\n"
+                        " -lan|inet                                 Private or public server (defaults to inet)\n"
                         "\n"
-                        " -password <password>         Private server password\n"
-                        " -ip <ip>                     Public IP address to register with.\n"
-                        " -port <port>                 Port to use (defaults to random 12000-12500)\n"
-                        " -verbosity {0-5}             Sets displayed log verbosity\n"
-                        " -log-verbosity {0-5}         Sets file log verbositylog verbosity\n"
-                        "                              levels available to verbosity and logverbosity:\n"
-                        "                                  0 = stack\n"
-                        "                                  1 = debug\n"
-                        "                                  2 = verbosity\n"
-                        "                                  3 = info\n"
-                        "                                  4 = warn\n"
-                        "                                  5 = error\n"
-                        " -log-file <server.log>       Sets the filename of the log\n"
-                        " -script-file <script.as>     Server script to execute\n"
-                        " -print-stats                 Prints stats to the console\n"
-                        " -version                     Prints the server version numbers\n"
-                        " -fg                          Starts the server in the foreground (background by default)\n"
-                        " -resource-dir <path>         Sets the path to the resource directory\n"
-                        " -auth-file <server.auth>             Path to file with authorization info\n"
-                        " -motd-file <server.motd>             Path to file with message of the day\n"
-                        " -rules-file <server.rules>           Path to file with rules for this server\n"
-                        " -blacklist-file <server.blacklist>   Path to file where bans are persisted\n"
-                        " -vehicle-limit {0-...}       Sets the maximum number of vehicles that a user is allowed to have\n"
-                        " -owner <name|organisation>   Sets the owner of this server (for the !owner command) (optional)\n"
-                        " -website <URL>               Sets the website of this server (for the !website command) (optional)\n"
-                        " -irc <URL>                   Sets the IRC url for this server (for the !irc command) (optional)\n"
-                        " -voip <URL>                  Sets the voip url for this server (for the !voip command) (optional)\n"
-                        " -help                        Show this list\n");
+                        " -password <password>                      Private server password\n"
+                        " -ip <ip>                                  Public IP address to register with.\n"
+                        " -port <port>                              Port to use (defaults to random 12000-12500)\n"
+                        " -verbosity {0-5}                          Sets displayed log verbosity\n"
+                        " -log-verbosity {0-5}                      Sets file log verbositylog verbosity\n"
+                        "                                           levels available to verbosity and logverbosity:\n"
+                        "                                               0 = stack\n"
+                        "                                               1 = debug\n"
+                        "                                               2 = verbosity\n"
+                        "                                               3 = info\n"
+                        "                                               4 = warn\n"
+                        "                                               5 = error\n"
+                        " -log-file <server.log>                    Sets the filename of the log\n"
+                        " -script-file <script.as>                  Server script to execute\n"
+                        " -print-stats                              Prints stats to the console\n"
+                        " -version                                  Prints the server version numbers\n"
+                        " -fg                                       Starts the server in the foreground (background by default)\n"
+                        " -resource-dir <path>                      Sets the path to the resource directory\n"
+                        " -auth-file <server.auth>                  Path to file with authorization info\n"
+                        " -motd-file <server.motd>                  Path to file with message of the day\n"
+                        " -rules-file <server.rules>                Path to file with rules for this server\n"
+                        " -blacklist-file <server.blacklist>        Path to file where bans are persisted\n"
+                        " -truck-blacklist-file <truck.blacklist>   Path to file where banned vehicles are persisted\n"
+                        " -vehicle-limit {0-...}                    Sets the maximum number of vehicles that a user is allowed to have\n"
+                        " -owner <name|organisation>                Sets the owner of this server (for the !owner command) (optional)\n"
+                        " -website <URL>                            Sets the website of this server (for the !website command) (optional)\n"
+                        " -irc <URL>                                Sets the IRC url for this server (for the !irc command) (optional)\n"
+                        " -voip <URL>                               Sets the voip url for this server (for the !voip command) (optional)\n"
+                        " -help                                     Show this list\n");
     }
 
     void ShowVersion() {
@@ -253,6 +255,7 @@ namespace Config {
             HANDLE_ARG_VALUE("motd-file", { setMOTDFile(value); });
             HANDLE_ARG_VALUE("rules-file", { setRulesFile(value); });
             HANDLE_ARG_VALUE("blacklist-file", { setBlacklistFile(value); });
+            HANDLE_ARG_VALUE("truck-blacklist-file", { setTruckBlacklistFile(value); });
             HANDLE_ARG_VALUE("owner", { setOwner(value); });
             HANDLE_ARG_VALUE("website", { setWebsite(value); });
             HANDLE_ARG_VALUE("irc", { setIRC(value); });
@@ -321,6 +324,8 @@ namespace Config {
     const std::string &getMOTDFile() { return s_motdfile; }
 
     const std::string &getBlacklistFile() { return s_blacklistfile; }
+
+    const std::string &getTruckBlacklistFile() { return s_truckblacklistfile; }
 
     const std::string &getRulesFile() { return s_rulesfile; }
 
@@ -417,6 +422,8 @@ namespace Config {
 
     void setBlacklistFile(const std::string &file) { s_blacklistfile = file; }
 
+    void setTruckBlacklistFile(const std::string &file) { s_truckblacklistfile = file; }
+
     void setMaxVehicles(unsigned int num) { s_max_vehicles = num; }
 
     void setSpawnIntervalSec(int sec) { s_spawn_interval_sec = sec; }
@@ -501,6 +508,7 @@ namespace Config {
         else if (strcmp(key, "motdfile") == 0) { setMOTDFile(VAL_STR (value)); }
         else if (strcmp(key, "rulesfile") == 0) { setRulesFile(VAL_STR (value)); }
         else if (strcmp(key, "blacklistfile") == 0) { setBlacklistFile(VAL_STR(value)); }
+        else if (strcmp(key, "truckblacklistfile") == 0) { setTruckBlacklistFile(VAL_STR(value)); }
         else if (strcmp(key, "owner") == 0) { setOwner(VAL_STR (value)); }
         else if (strcmp(key, "website") == 0) { setWebsite(VAL_STR (value)); }
         else if (strcmp(key, "irc") == 0) { setIRC(VAL_STR (value)); }

--- a/source/server/config.h
+++ b/source/server/config.h
@@ -102,7 +102,7 @@ namespace Config {
     bool GetShowVersion();
 
     // Vehicle spawn limits
-    unsigned int getMaxVehicles();
+    int getMaxVehicles();
     int getSpawnIntervalSec();
     int getMaxSpawnRate();
 

--- a/source/server/config.h
+++ b/source/server/config.h
@@ -77,6 +77,8 @@ namespace Config {
 
     const std::string &getBlacklistFile();
 
+    const std::string &getTruckBlacklistFile();
+
     const std::string &getOwner();
 
     const std::string &getWebsite();
@@ -147,6 +149,8 @@ namespace Config {
     void setRulesFile(const std::string &rulesFile);
 
     void setBlacklistFile(const std::string &blacklistFile);
+
+    void setTruckBlacklistFile(const std::string &blacklistFile);
 
     void setOwner(const std::string &owner);
 

--- a/source/server/sequencer.cpp
+++ b/source/server/sequencer.cpp
@@ -803,7 +803,7 @@ void Sequencer::queueMessage(int uid, int type, unsigned int streamid, char *dat
         }
     } else if (type == RoRnet::MSG2_STREAM_REGISTER) {
         RoRnet::StreamRegister *reg = (RoRnet::StreamRegister *) data;
-        const int numVehicles = client->countStreamsByType(0); // type 0 = vehicle
+        const int numVehicles = client->countStreamsByType(RORNET_STREAM_TYPE_VEHICLE);
         if (numVehicles >= Config::getMaxVehicles()) {
             // This user has too many vehicles, we drop the stream and then disconnect the user
             Logger::Log(LOG_INFO, "%s(%d) has too many streams. Stream dropped, user kicked.",
@@ -821,7 +821,7 @@ void Sequencer::queueMessage(int uid, int type, unsigned int streamid, char *dat
 
             QueueClientForDisconnect(client->user.uniqueid, "You have too many vehicles. Please rejoin.", false);
             publishMode = BROADCAST_BLOCK; // drop
-        } else if (reg->type == STREAM_REG_TYPE_VEHICLE && !client->CheckSpawnRate()) {
+        } else if (reg->type == RORNET_STREAM_TYPE_VEHICLE && !client->CheckSpawnRate()) {
             // This user spawns vehicles too fast, we drop the stream and then disconnect the user
             Logger::Log(LOG_INFO, "%s(%d) spawns vehicles too fast. Stream dropped, user kicked.",
                         client->GetUsername().c_str(), client->user.uniqueid);
@@ -837,7 +837,7 @@ void Sequencer::queueMessage(int uid, int type, unsigned int streamid, char *dat
                     Config::getMaxSpawnRate(), Config::getSpawnIntervalSec());
             QueueClientForDisconnect(client->user.uniqueid, sayMsg, false);
             publishMode = BROADCAST_BLOCK; // drop
-        } else if (reg->type == STREAM_REG_TYPE_VEHICLE && !Utils::isValidVehicleFileName(reg->name)) {
+        } else if (reg->type == RORNET_STREAM_TYPE_VEHICLE && !Utils::isValidVehicleFileName(reg->name)) {
             // This user spawned vehicle with empty or malformed name, we drop the stream and then disconnect the user
             Logger::Log(LOG_INFO, "%s(%d) spawned vehicle with empty/malformed name. Stream dropped, user kicked.",
                         client->GetUsername().c_str(), client->user.uniqueid);
@@ -893,7 +893,7 @@ void Sequencer::queueMessage(int uid, int type, unsigned int streamid, char *dat
                                                    std::string(reg->name), std::string());
 
                 // Notify the user about the vehicle limit
-                const int numVehicles = client->countStreamsByType(0); // type 0 = vehicle
+                const int numVehicles = client->countStreamsByType(RORNET_STREAM_TYPE_VEHICLE);
                 // we start warning the user as soon as he has only 3 vehicles left before he will get kicked
                 if (numVehicles >= (Config::getMaxVehicles() - 3)) {
                     char sayMsg[128] = "";

--- a/source/server/sequencer.h
+++ b/source/server/sequencer.h
@@ -42,10 +42,6 @@ along with Foobar. If not, see <http://www.gnu.org/licenses/>.
 #include <vector>
 #include <map>
 
-// How many not-vehicles streams has every user by default? (e.g.: "default" and "chat" are not-vehicles streams)
-// This is used for the vehicle-limit
-#define NON_VEHICLE_STREAMS 2
-
 // Specified by RoR; used for spawn-rate limit
 #define STREAM_REG_TYPE_VEHICLE 0
 
@@ -130,7 +126,7 @@ public:
 
     SpamFilter& GetSpamFilter() { return m_spamfilter; }
 
-    Sequencer* GetSequencer() {  }
+    int countStreamsByType(int type);
 
     RoRnet::UserInfo user;  //!< user information
 

--- a/source/server/sequencer.h
+++ b/source/server/sequencer.h
@@ -21,6 +21,7 @@ along with Foobar. If not, see <http://www.gnu.org/licenses/>.
 #pragma once
 
 #include "blacklist.h"
+#include "truckblacklist.h"
 #include "prerequisites.h"
 #include "rornet.h"
 #include "mutexutils.h"
@@ -172,6 +173,10 @@ struct ban_t {
     char banmsg[256];           //!< why he got banned
 };
 
+struct vehicleban_t {
+    std::string filename;         //!< banned file name with extension
+};
+
 void *LaunchKillerThread(void *);
 
 class Sequencer {
@@ -248,7 +253,17 @@ public:
 
     std::vector<WebserverClientInfo> GetClientListCopy();
 
+    std::vector<vehicleban_t> GetTruckBanListCopy();
+
     std::vector<ban_t> GetBanListCopy();
+
+    /// @name Vehicle bans
+    /// @{
+    bool banVehicle(std::string const& filename);
+    bool unBanVehicle(std::string const& filename);
+    bool isTruckFileBanned(const char *filename);
+    std::vector<vehicleban_t> getVehicleBanListCopy();
+    /// @}
 
     static unsigned int connCrash, connCount;
 
@@ -265,10 +280,12 @@ private:
     size_t m_num_disconnects_total; //!< Statistic
     size_t m_num_disconnects_crash; //!< Statistic
     Blacklist m_blacklist;
+    TruckBlacklist m_truck_blacklist;
 
     std::queue<Client *> m_kill_queue; //!< holds pointer for client deletion
     std::vector<Client *> m_clients;
     std::vector<ban_t *> m_bans;
+    std::vector<vehicleban_t *> m_vehiclebans;
 
     Client *FindClientById(unsigned int client_id);
 };

--- a/source/server/sequencer.h
+++ b/source/server/sequencer.h
@@ -42,9 +42,6 @@ along with Foobar. If not, see <http://www.gnu.org/licenses/>.
 #include <vector>
 #include <map>
 
-// Specified by RoR; used for spawn-rate limit
-#define STREAM_REG_TYPE_VEHICLE 0
-
 #define SEQUENCER Sequencer::Instance()
 
 #define VERSION __DATE__

--- a/source/server/truckblacklist.cpp
+++ b/source/server/truckblacklist.cpp
@@ -1,0 +1,103 @@
+/*
+This file is part of "Rigs of Rods Server" (Relay mode)
+
+Copyright 2007   Pierre-Michel Ricordel
+Copyright 2014+  Rigs of Rods Community
+
+"Rigs of Rods Server" is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+"Rigs of Rods Server" is distributed in the hope that it will
+be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Rigs of Rods Server. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "truckblacklist.h"
+#include "config.h"
+#include "logger.h"
+#include "sequencer.h"
+#include "utils.h"
+
+#include <fstream>
+#include <json/json.h>
+
+TruckBlacklist::TruckBlacklist(Sequencer* database)
+    : m_database(database)
+{
+}
+
+void TruckBlacklist::SaveTruckBlacklistToFile()
+{
+    std::ofstream f;
+    f.open(Config::getTruckBlacklistFile(), std::ios::out);
+    if (!f.is_open() || !f.good())
+    {
+        Logger::Log(LogLevel::LOG_WARN,
+            "Couldn't open the local truck blacklist file ('%s'). Bans were not saved.",
+            Config::getTruckBlacklistFile().c_str());
+        return;
+    }
+
+    Json::Value j_bans(Json::arrayValue);
+    std::vector<vehicleban_t> bans = m_database->GetTruckBanListCopy();
+
+    for (vehicleban_t& ban : bans)
+    {
+        Json::Value j_ban(Json::objectValue);
+        j_ban["filename"] = ban.filename;
+        j_bans.append(j_ban);
+    }
+
+    Json::Value j_doc(Json::objectValue);
+    j_doc["bans"] = j_bans;
+
+    Json::StyledStreamWriter j_writer;
+    j_writer.write(f, j_doc);
+}
+
+bool TruckBlacklist::LoadTruckBlacklistFromFile()
+{
+    std::ifstream f;
+    f.open(Config::getTruckBlacklistFile(), std::ios::in);
+    if (!f.is_open() || !f.good())
+    {
+        Logger::Log(LogLevel::LOG_WARN,
+                    "Couldn't open the local truck blacklist file ('%s'). No bans were loaded.",
+                    Config::getTruckBlacklistFile().c_str());
+        return false;
+    }
+
+    if (Utils::IsEmptyFile(f))
+    {
+        f.close();
+        Logger::Log(LogLevel::LOG_WARN,
+                    "Local blacklist file ('%s') is empty.",
+                    Config::getTruckBlacklistFile().c_str());
+        return false;
+    }
+
+    Json::Value j_doc;
+    Json::Reader j_reader;
+    j_reader.parse(f, j_doc);
+    if (!j_reader.good())
+    {
+        Logger::Log(LogLevel::LOG_WARN,
+                    "Couldn't parse blacklist file, messages:\n%s",
+                    j_reader.getFormattedErrorMessages());
+        return false;
+    }
+
+    for (Json::Value& j_ban: j_doc["bans"])
+    {
+        m_database->banVehicle(
+            j_ban["filename"].asString());
+    }
+
+    return true;
+}

--- a/source/server/truckblacklist.h
+++ b/source/server/truckblacklist.h
@@ -1,0 +1,40 @@
+/*
+This file is part of "Rigs of Rods Server" (Relay mode)
+
+Copyright 2007   Pierre-Michel Ricordel
+Copyright 2014+  Rigs of Rods Community
+
+"Rigs of Rods Server" is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+"Rigs of Rods Server" is distributed in the hope that it will
+be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Rigs of Rods Server. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+/// @file Persistent blacklist of users or contents
+/// @author Petr Ohlidal, 2019
+///    Data structures are historically defined in sequencer.h
+
+#include "prerequisites.h"
+
+class TruckBlacklist
+{
+public:
+    TruckBlacklist(Sequencer* database);
+
+    void SaveTruckBlacklistToFile();
+    bool LoadTruckBlacklistFromFile();
+
+private:
+    Sequencer* m_database;
+};
+


### PR DESCRIPTION
Based on Discord chat with @tritonas00

Currently vehicle blacklist is stored directly in RoRServerScripts source code, which is PITA to maintain, a server restart is required.

This PR introduces new priviledged chat commands `!banvehicle`, `!unbanvehicle` and `!vehiclebans` which reads/writes from/to 'truck.blacklist' file.

Also added a `!reload` command which reads 'truck.blacklist' without server restart, to notify multiple servers.