### PR TITLE
Unban players using IPs

### DIFF
--- a/source/server/blacklist.cpp
+++ b/source/server/blacklist.cpp
@@ -100,7 +100,7 @@ bool Blacklist::LoadBlacklistFromFile()
     for (Json::Value& j_ban: j_doc["bans"])
     {
         m_database->RecordBan(
-			j_ban["bid"].asInt(),
+            // ban IDs are reset to start at 1 on every start/restart
             j_ban["ip"].asString(),
             j_ban["nickname"].asString(),
             j_ban["banned_by_nickname"].asString(),

--- a/source/server/sequencer.h
+++ b/source/server/sequencer.h
@@ -234,8 +234,9 @@ private:
     bool                     Kick(int to_kick_uid, int modUID, const char *msg = 0);
     bool                     Ban(int to_ban_uid, int modUID, const char *msg = 0);
     void                     SilentBan(int to_ban_uid, const char *msg = 0, bool doScriptCallback = true);
-    void                     RecordBan(int bid, std::string const& ip_addr, std::string const& nickname, std::string const& by_nickname, std::string const& banmsg);
+    void                     RecordBan(std::string const& ip_addr, std::string const& nickname, std::string const& by_nickname, std::string const& banmsg);
     bool                     IsBanned(const char *ip);
+    bool                     UnBanIP(std::string ip_addr);
     bool                     UnBan(int bid);
     void                     streamDebug();
     std::vector<ban_t>       GetBanListCopy();


### PR DESCRIPTION
It becomes nearly impossible to sort through 500 or more ban records to get a ban ID and unban a player. To make things easier, ban IDs are auto incremented on start/restart and you will now be able to unban a player by IP (which is always unique). 