### PR TITLE
Now supporting net performance graphs on client.

### DIFF
--- a/source/server/broadcaster.h
+++ b/source/server/broadcaster.h
@@ -29,10 +29,7 @@ along with Foobar. If not, see <http://www.gnu.org/licenses/>.
 #include <thread>
 
 struct QueueEntry {
-    RoRnet::MessageType type = RoRnet::MSG2_INVALID;
-    int uid;
-    unsigned int streamid;
-    unsigned int datalen;
+    RoRnet::Header header;
     char data[RORNET_MAX_MESSAGE_LENGTH];
 };
 
@@ -55,7 +52,7 @@ public:
     void Start(Client* client);
     void Stop();
 
-    void QueueMessage(int msg_type, int client_id, unsigned int streamid, unsigned int payload_len, const char *payload);
+    void QueuePacket(RoRnet::Header header, const char *payload);
     bool IsDroppingPackets() const { return m_is_dropping_packets; }
 
 private:

--- a/source/server/messaging.h
+++ b/source/server/messaging.h
@@ -34,6 +34,11 @@ namespace Messaging {
             unsigned int payload_len,
             const char *payload);
 
+    int SendMessageWithHeader(
+            SWInetSocket *socket,
+            RoRnet::Header header,
+            const char *payload);
+
     int ReceiveMessage(
             SWInetSocket *socket,
             int *out_msg_type,

--- a/source/server/receiver.cpp
+++ b/source/server/receiver.cpp
@@ -96,8 +96,7 @@ void Receiver::ThreadMain() {
             break;
         }
 
-        m_sequencer->queueMessage(m_client->GetUserId(),
-            (int)m_recv_header.command, m_recv_header.streamid, m_recv_payload, m_recv_header.size);
+        m_sequencer->queueMessage(m_recv_header, m_recv_payload);
     }
 
     Logger::Log(LOG_DEBUG, "Receiver thread (user ID %d) exits", m_client->GetUserId());

--- a/source/server/sequencer.h
+++ b/source/server/sequencer.h
@@ -109,6 +109,7 @@ public:
     void Disconnect();
 
     void QueueMessage(int msg_type, int client_id, unsigned int stream_id, unsigned int payload_len, const char *payload);
+    void QueueMessageWithHeader(RoRnet::Header header, const char *payload);
 
     void NotifyAllVehicles(Sequencer *sequencer);
 
@@ -204,7 +205,8 @@ public:
     void createClient(SWInetSocket *sock, RoRnet::UserInfo user);
     void disconnectClient(int client_id, const char* error, bool isError = true, bool doScriptCallback = true);
     int getNumClients();
-    void queueMessage(int uid, int type, unsigned int streamid, char *data, unsigned int len);
+    void queueMessage(RoRnet::Header header, char *data);
+    void sendStreamData(Client *dst_client, RoRnet::Header header, char *data);
     void sendMOTDSynchronized(int uid);
     void frameStepScripts(float dt);
     void GetHeartbeatUserList(Json::Value &out_array);


### PR DESCRIPTION
See https://github.com/RigsOfRods/rigs-of-rods/pull/3056 - `RoRnet::Header` was updated with extra timestamps to track network performance. The problem is, the server didn't transfer the header as-is, so the data got lost. I added code to transfer the headers as-is, but to avoid massive commit, I left all the server messages as-is, only changed processing messages from clients.

**Changes:**
- RoRnet updated to support new timestamps
- Messaging: added `SendMessageWithHeader()`
- Broadcaster - transformed `QueueMessage()` with separate values to `QueuePacket` with header.
- Sequencer - accept and broadcast the entire header. Added `sendStreamData()` helper for that.

Time spent: 2.5h, not counting client.