### PR TITLE
Version bump to RoRnet_2.45

### DIFF
--- a/source/protocol/rornet.h
+++ b/source/protocol/rornet.h
@@ -30,7 +30,7 @@ namespace RoRnet {
 #define RORNET_LAN_BROADCAST_PORT   13000  //!< port used to send the broadcast announcement in LAN mode
 #define RORNET_MAX_USERNAME_LEN     40     //!< port used to send the broadcast announcement in LAN mode
 
-#define RORNET_VERSION              "RoRnet_2.44"
+#define RORNET_VERSION              "RoRnet_2.45"
 
 enum MessageType
 {


### PR DESCRIPTION
This accomodates 2 backwards-incompatible changes:
* https://github.com/RigsOfRods/rigs-of-rods/pull/3171 
* https://github.com/RigsOfRods/rigs-of-rods/pull/3055 