### PR TITLE
CURL support via scripting.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,9 @@ find_package(Threads REQUIRED)
 find_package(Angelscript)
 find_package(jsoncpp REQUIRED)
 find_package(SocketW REQUIRED)
-
+find_package(CURL)
 cmake_dependent_option(RORSERVER_WITH_ANGELSCRIPT "Adds scripting support" ON "TARGET Angelscript::angelscript" OFF)
+cmake_dependent_option(RORSERVER_WITH_CURL "Adds CURL request support (needs AngelScript)" ON "TARGET CURL::libcurl" OFF)
 
 # setup paths
 SET(RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin/")

--- a/conanfile.py
+++ b/conanfile.py
@@ -16,3 +16,4 @@ class RoRServer(ConanFile):
         self.requires("jsoncpp/1.9.5")
         self.requires("openssl/3.3.2", override=True)
         self.requires("socketw/3.11.0@anotherfoxguy/stable")
+        self.requires("libcurl/8.10.1")

--- a/source/server/CMakeLists.txt
+++ b/source/server/CMakeLists.txt
@@ -15,6 +15,11 @@ if (RORSERVER_WITH_ANGELSCRIPT)
     target_link_libraries(${PROJECT_NAME} PRIVATE Angelscript::angelscript angelscript_addons)
 endif ()
 
+if (RORSERVER_WITH_CURL)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE WITH_CURL)
+    target_link_libraries(${PROJECT_NAME} PRIVATE CURL::libcurl)
+endif ()
+
 target_link_libraries(${PROJECT_NAME} PRIVATE Threads::Threads SocketW::SocketW jsoncpp_lib)
 
 IF (WIN32)

--- a/source/server/CurlHelpers.cpp
+++ b/source/server/CurlHelpers.cpp
@@ -1,0 +1,99 @@
+/*
+    This source file is part of Rigs of Rods
+    Copyright 2005-2012 Pierre-Michel Ricordel
+    Copyright 2007-2012 Thomas Fischer
+    Copyright 2013-2023 Petr Ohlidal
+
+    For more information, see http://www.rigsofrods.org/
+
+    Rigs of Rods is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 3, as
+    published by the Free Software Foundation.
+
+    Rigs of Rods is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Rigs of Rods. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifdef WITH_CURL
+
+#include "CurlHelpers.h"
+#include "ScriptEngine.h"
+
+#include <curl/curl.h>
+#include <curl/easy.h>
+
+#include <string>
+
+static size_t CurlStringWriteFunc(void *ptr, size_t size, size_t nmemb, std::string* data)
+{
+    data->append((char*)ptr, size * nmemb);
+    return size * nmemb;
+}
+
+static size_t CurlXferInfoFunc(void* ptr, curl_off_t filesize_B, curl_off_t downloaded_B, curl_off_t uploadsize_B, curl_off_t uploaded_B)
+{
+    CurlTaskContext* context = (CurlTaskContext*)ptr;
+
+    context->ctc_script_engine->curlStatus(
+        CURL_STATUS_PROGRESS, (int)downloaded_B, (int)filesize_B, context->ctc_displayname, "");
+
+    // If you don't return 0, the transfer will be aborted - see the documentation
+    return 0;
+}
+
+bool GetUrlAsString(const std::string& url, CURLcode& curl_result, long& response_code, std::string& response_payload)
+{
+    std::string response_header;
+    std::string user_agent = "Rigs of Rods Server";
+
+    CURL *curl = curl_easy_init();
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V4);
+#ifdef _WIN32
+    curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
+#endif // _WIN32
+    curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "gzip");
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, user_agent.c_str());
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, CurlStringWriteFunc);
+    curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, CurlXferInfoFunc);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response_payload);
+    curl_easy_setopt(curl, CURLOPT_HEADERDATA, &response_header);
+
+    curl_result = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &response_code);
+
+    curl_easy_cleanup(curl);
+    curl = nullptr;
+
+    if (curl_result != CURLE_OK || response_code != 200)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool CurlRequestThreadFunc(CurlTaskContext context)
+{
+    context.ctc_script_engine->curlStatus(CURL_STATUS_START, 0, 0, context.ctc_displayname, "");
+    std::string data;
+    CURLcode curl_result = CURLE_OK;
+    long http_response = 0;
+    if (GetUrlAsString(context.ctc_url, /*out:*/curl_result, /*out:*/http_response, /*out:*/data))
+    {
+        context.ctc_script_engine->curlStatus(CURL_STATUS_SUCCESS, (int)curl_result, (int)http_response, context.ctc_displayname, data);
+        return true;
+    }
+    else
+    {
+        context.ctc_script_engine->curlStatus(CURL_STATUS_FAILURE, (int)curl_result, (int)http_response, context.ctc_displayname, curl_easy_strerror(curl_result));
+        return false;
+    }
+}
+
+#endif // WITH_CURL

--- a/source/server/CurlHelpers.h
+++ b/source/server/CurlHelpers.h
@@ -1,0 +1,57 @@
+/*
+This file is part of "Rigs of Rods Server" (Relay mode)
+
+Copyright 2007   Pierre-Michel Ricordel
+Copyright 2014+  Rigs of Rods Community
+
+"Rigs of Rods Server" is free software: you can redistribute it
+and/or modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation, either version 3
+of the License, or (at your option) any later version.
+
+"Rigs of Rods Server" is distributed in the hope that it will
+be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Foobar. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#pragma once
+
+enum CurlStatusType
+{
+    CURL_STATUS_INVALID,  //!< Should never be reported.
+    CURL_STATUS_START,    //!< New CURL request started, n1/n2 both 0.
+    CURL_STATUS_PROGRESS, //!< Download in progress, n1 = bytes downloaded, n2 = total bytes.
+    CURL_STATUS_SUCCESS,  //!< CURL request finished, n1 = CURL return code, n2 = HTTP result code, message = received payload.
+    CURL_STATUS_FAILURE,  //!< CURL request finished, n1 = CURL return code, n2 = HTTP result code, message = CURL error string.
+};
+
+#ifdef WITH_CURL
+
+class ScriptEngine;
+
+#include <curl/curl.h>
+#include <curl/easy.h>
+
+#include <string>
+
+
+struct CurlTaskContext
+{
+    std::string ctc_displayname;
+    std::string ctc_url;
+    ScriptEngine* ctc_script_engine;
+    // Status is reported via new server callback `curlStatus()`
+};
+
+bool GetUrlAsString(const std::string& url, CURLcode& curl_result, long& response_code, std::string& response_payload);
+
+bool CurlRequestThreadFunc(CurlTaskContext task);
+
+
+
+#endif // WITH_CURL

--- a/source/server/ScriptEngine.cpp
+++ b/source/server/ScriptEngine.cpp
@@ -285,7 +285,9 @@ void ScriptEngine::PrintVariables(asIScriptContext *ctx, int stackLevel) {
     // Print the value of each variable, including parameters
     int numVars = ctx->GetVarCount(stackLevel);
     for (int n = 0; n < numVars; n++) {
-        int typeId = ctx->GetVarTypeId(n, stackLevel);
+        int typeId = -1;
+        const char* varName = nullptr;
+        ctx->GetVar(n, stackLevel, &varName, &typeId);
         void *varPointer = ctx->GetAddressOfVar(n, stackLevel);
         if (typeId == asTYPEID_INT32) {
             Logger::Log(LOG_INFO, " %s = %d", ctx->GetVarDeclaration(n, stackLevel), *(int *) varPointer);

--- a/source/server/sequencer.h
+++ b/source/server/sequencer.h
@@ -132,8 +132,6 @@ public:
 
     SpamFilter& GetSpamFilter() { return m_spamfilter; }
 
-    Sequencer* GetSequencer() {  }
-
     RoRnet::UserInfo user;  //!< user information
 
     int drop_state;             // dropping outgoing packets?


### PR DESCRIPTION
Added a CURL request function to scripting API. Please see updated 'example-script.as' for all details.

To test, spin up a server with the example script and say "CURL test" in chat - this sends a GET request to `https://www.rigsofrods.org`.

