### PR TITLE
:wastebasket: Fix deprecated AngelScript func `GetVarTypeId`

### DIFF
--- a/source/server/ScriptEngine.cpp
+++ b/source/server/ScriptEngine.cpp
@@ -285,7 +285,9 @@ void ScriptEngine::PrintVariables(asIScriptContext *ctx, int stackLevel) {
     // Print the value of each variable, including parameters
     int numVars = ctx->GetVarCount(stackLevel);
     for (int n = 0; n < numVars; n++) {
-        int typeId = ctx->GetVarTypeId(n, stackLevel);
+        int typeId = -1;
+        const char* varName = nullptr;
+        ctx->GetVar(n, stackLevel, &varName, &typeId);
         void *varPointer = ctx->GetAddressOfVar(n, stackLevel);
         if (typeId == asTYPEID_INT32) {
             Logger::Log(LOG_INFO, " %s = %d", ctx->GetVarDeclaration(n, stackLevel), *(int *) varPointer);


### PR DESCRIPTION
Per <angelscript.h> // deprecated since 2022-05-04, 2.36.0

Tested by running a script with division by zero:
```
22-01-2025 21:58:23|t19104| INFO|--- exception ---
22-01-2025 21:58:23|t19104| INFO|desc: Divide by zero
22-01-2025 21:58:23|t19104| INFO|func: void myFrameCallback(float)
22-01-2025 21:58:23|t19104| INFO|modl: script
22-01-2025 21:58:23|t19104| INFO|sect: c:/Users/ohlidalp/hobby/source/ror-server/contrib/example-script.as
22-01-2025 21:58:23|t19104| INFO|line: 136,9
22-01-2025 21:58:23|t19104| INFO|--- call stack ---
22-01-2025 21:58:23|t19104| INFO|c:/Users/ohlidalp/hobby/source/ror-server/contrib/example-script.as (136): void myFrameCallback(float)
22-01-2025 21:58:23|t19104| INFO| float dt_millis = 200.000000
22-01-2025 21:58:23|t19104| INFO| int  = 0
22-01-2025 21:58:23|t19104| INFO| int  = 1098068777
22-01-2025 21:58:23|t19104| INFO| string  = 'Example server script: myFrameCallback(): total time is '
22-01-2025 21:58:23|t19104| INFO| string  = <null>
22-01-2025 21:58:23|t19104| INFO| int  = 0
22-01-2025 21:58:23|t19104| INFO| const int  = 478
22-01-2025 21:58:23|t19104| INFO|--- end of script exception message ---
```